### PR TITLE
Update IS_vibrations_measurements.cfg

### DIFF
--- a/K-ShakeTune/IS_vibrations_measurements.cfg
+++ b/K-ShakeTune/IS_vibrations_measurements.cfg
@@ -157,7 +157,7 @@ gcode:
 
     M83
     G90
-    SET_VELOCITY_LIMIT ACCEL={accel} ACCEL_TO_DECEL={accel}
+    SET_ACCEL_LIMIT ACCEL={accel} ACCEL_TO_DECEL={accel}
     # Going to the start position
     G1 Z{z_height}
     G1 X{mid_x + (size * direction_factor[direction].start.x) } Y{mid_y + (size * direction_factor[direction].start.y)} F{feedrate_travel}

--- a/K-ShakeTune/IS_vibrations_measurements.cfg
+++ b/K-ShakeTune/IS_vibrations_measurements.cfg
@@ -45,7 +45,7 @@ gcode:
     {% set max_speed = params.MAX_SPEED|default(200)|float * 60 %} # maximum feedrate for the movements
     {% set speed_increment = params.SPEED_INCREMENT|default(2)|float * 60 %} # feedrate increment between each move
     {% set feedrate_travel = params.TRAVEL_SPEED|default(200)|int * 60 %} # travel feedrate between moves
-
+    {% set accel = params.ACCEL|default(config.printer["max_accel"])|float %}
     {% set accel_chip = params.ACCEL_CHIP|default("adxl345") %} # ADXL chip name in the config
 
     #

--- a/K-ShakeTune/IS_vibrations_measurements.cfg
+++ b/K-ShakeTune/IS_vibrations_measurements.cfg
@@ -157,7 +157,7 @@ gcode:
 
     M83
     G90
-
+    SET_VELOCITY_LIMIT ACCEL={accel} ACCEL_TO_DECEL={accel}
     # Going to the start position
     G1 Z{z_height}
     G1 X{mid_x + (size * direction_factor[direction].start.x) } Y{mid_y + (size * direction_factor[direction].start.y)} F{feedrate_travel}


### PR DESCRIPTION
Include the acceleration value explicitly. Otherwise, it defaults to the `max_acceleration` value from the printer configuration, which in most cases does not match the printing acceleration. If people use the slicer limiter and set a high `max_acceleration` in the printer.cfg, it can potentially cause damage.