### PR TITLE
Replace max_accel_to_decel with minimum_cruise_ratio

### DIFF
--- a/K-ShakeTune/K-SnT_axes_map.cfg
+++ b/K-ShakeTune/K-SnT_axes_map.cfg
@@ -16,7 +16,7 @@ gcode:
 
     {% set accel = [accel, printer.configfile.settings.printer.max_accel]|min %}
     {% set old_accel = printer.toolhead.max_accel %}
-    {% set old_accel_to_decel = printer.toolhead.max_accel_to_decel %}
+    {% set old_cruise_ratio = printer.toolhead.minimum_cruise_ratio %}
     {% set old_sqv = printer.toolhead.square_corner_velocity %}
 
 
@@ -34,7 +34,7 @@ gcode:
     G90
 
     # Set the wanted acceleration values (not too high to avoid oscillation, not too low to be able to reach constant speed on each segments)
-    SET_VELOCITY_LIMIT ACCEL={accel} ACCEL_TO_DECEL={accel} SQUARE_CORNER_VELOCITY={[(accel / 1000), 5.0]|max}
+    SET_VELOCITY_LIMIT ACCEL={accel} MINIMUM_CRUISE_RATIO=0 SQUARE_CORNER_VELOCITY={[(accel / 1000), 5.0]|max}
     
     # Going to the start position
     G1 Z{z_height} F{feedrate_travel / 8}
@@ -55,6 +55,6 @@ gcode:
     RUN_SHELL_COMMAND CMD=shaketune PARAMS="--type axesmap --accel {accel|int} --chip_name {accel_chip}"
 
     # Restore the previous acceleration values
-    SET_VELOCITY_LIMIT ACCEL={old_accel} ACCEL_TO_DECEL={old_accel_to_decel} SQUARE_CORNER_VELOCITY={old_sqv}
+    SET_VELOCITY_LIMIT ACCEL={old_accel} MINIMUM_CRUISE_RATIO={old_cruise_ratio} SQUARE_CORNER_VELOCITY={old_sqv}
 
     RESTORE_GCODE_STATE NAME=STATE_AXESMAP_CALIBRATION

--- a/K-ShakeTune/K-SnT_vibrations.cfg
+++ b/K-ShakeTune/K-SnT_vibrations.cfg
@@ -25,7 +25,7 @@ gcode:
 
     {% set accel = [accel, printer.configfile.settings.printer.max_accel]|min %}
     {% set old_accel = printer.toolhead.max_accel %}
-    {% set old_accel_to_decel = printer.toolhead.max_accel_to_decel %}
+    {% set old_cruise_ratio = printer.toolhead.minimum_cruise_ratio %}
     {% set old_sqv = printer.toolhead.square_corner_velocity %}
 
     {% set direction_factor = {
@@ -129,7 +129,7 @@ gcode:
     G90
 
     # Set the wanted acceleration values (not too high to avoid oscillation, not too low to be able to reach constant speed on each segments)
-    SET_VELOCITY_LIMIT ACCEL={accel} ACCEL_TO_DECEL={accel} SQUARE_CORNER_VELOCITY={[(accel / 1000), 5.0]|max}
+    SET_VELOCITY_LIMIT ACCEL={accel} MINIMUM_CRUISE_RATIO=0 SQUARE_CORNER_VELOCITY={[(accel / 1000), 5.0]|max}
     
     # Going to the start position
     G1 Z{z_height} F{feedrate_travel / 10}
@@ -161,6 +161,6 @@ gcode:
     RUN_SHELL_COMMAND CMD=shaketune PARAMS="--type clean --keep_results {keep_results}"
 
     # Restore the previous acceleration values
-    SET_VELOCITY_LIMIT ACCEL={old_accel} ACCEL_TO_DECEL={old_accel_to_decel} SQUARE_CORNER_VELOCITY={old_sqv}
+    SET_VELOCITY_LIMIT ACCEL={old_accel} MINIMUM_CRUISE_RATIO={old_cruise_ratio} SQUARE_CORNER_VELOCITY={old_sqv}
 
     RESTORE_GCODE_STATE NAME=STATE_VIBRATIONS_CALIBRATION


### PR DESCRIPTION
Considering the changes in Klipper as per [#6418](https://github.com/Klipper3d/klipper/pull/6418) this PR replaces the old `max_accel_to_decel` value with the new `minimum_cruise_ratio` for the tests.