### PR TITLE
fix random Timer too close or Move queue overflow errors

### DIFF
--- a/shaketune/commands/axes_map_calibration.py
+++ b/shaketune/commands/axes_map_calibration.py
@@ -82,6 +82,8 @@ def axes_map_calibration(gcmd, config, st_process: ShakeTuneProcess) -> None:
     toolhead.dwell(0.5)
     accelerometer.stop_measurement('axesmap_Z', append_time=True)
 
+    del accelerometer
+
     # Re-enable the input shaper if it was active
     if input_shaper is not None:
         input_shaper.enable_shaping()

--- a/shaketune/commands/axes_map_calibration.py
+++ b/shaketune/commands/axes_map_calibration.py
@@ -82,7 +82,7 @@ def axes_map_calibration(gcmd, config, st_process: ShakeTuneProcess) -> None:
     toolhead.dwell(0.5)
     accelerometer.stop_measurement('axesmap_Z', append_time=True)
 
-    del accelerometer
+    accelerometer.wait_for_file_writes()
 
     # Re-enable the input shaper if it was active
     if input_shaper is not None:

--- a/shaketune/commands/axes_shaper_calibration.py
+++ b/shaketune/commands/axes_shaper_calibration.py
@@ -103,6 +103,8 @@ def axes_shaper_calibration(gcmd, config, st_process: ShakeTuneProcess) -> None:
         vibrate_axis(toolhead, gcode, config['direction'], min_freq, max_freq, hz_per_sec, accel_per_hz)
         accelerometer.stop_measurement(config['label'], append_time=True)
 
+        del accelerometer
+
         # And finally generate the graph for each measured axis
         ConsoleOutput.print(f'{config["axis"].upper()} axis frequency profile generation...')
         ConsoleOutput.print('This may take some time (1-3min)')

--- a/shaketune/commands/axes_shaper_calibration.py
+++ b/shaketune/commands/axes_shaper_calibration.py
@@ -103,7 +103,7 @@ def axes_shaper_calibration(gcmd, config, st_process: ShakeTuneProcess) -> None:
         vibrate_axis(toolhead, gcode, config['direction'], min_freq, max_freq, hz_per_sec, accel_per_hz)
         accelerometer.stop_measurement(config['label'], append_time=True)
 
-        del accelerometer
+        accelerometer.wait_for_file_writes()
 
         # And finally generate the graph for each measured axis
         ConsoleOutput.print(f'{config["axis"].upper()} axis frequency profile generation...')

--- a/shaketune/commands/compare_belts_responses.py
+++ b/shaketune/commands/compare_belts_responses.py
@@ -58,6 +58,7 @@ def compare_belts_responses(gcmd, config, st_process: ShakeTuneProcess) -> None:
         raise gcmd.error(
             'No suitable accelerometer found for measurement! Multi-accelerometer configurations are not supported for this macro.'
         )
+    accelerometer = Accelerometer(printer.lookup_object(accel_chip))
 
     # Move to the starting point
     test_points = res_tester.test.get_start_test_points()
@@ -98,11 +99,11 @@ def compare_belts_responses(gcmd, config, st_process: ShakeTuneProcess) -> None:
 
     # Run the test for each axis
     for config in filtered_config:
-        accelerometer = Accelerometer(printer.lookup_object(accel_chip))
         accelerometer.start_measurement()
         vibrate_axis(toolhead, gcode, config['direction'], min_freq, max_freq, hz_per_sec, accel_per_hz)
         accelerometer.stop_measurement(config['label'], append_time=True)
-        del accelerometer
+
+    accelerometer.wait_for_file_writes()
 
     # Re-enable the input shaper if it was active
     if input_shaper is not None:

--- a/shaketune/commands/compare_belts_responses.py
+++ b/shaketune/commands/compare_belts_responses.py
@@ -58,7 +58,6 @@ def compare_belts_responses(gcmd, config, st_process: ShakeTuneProcess) -> None:
         raise gcmd.error(
             'No suitable accelerometer found for measurement! Multi-accelerometer configurations are not supported for this macro.'
         )
-    accelerometer = Accelerometer(printer.lookup_object(accel_chip))
 
     # Move to the starting point
     test_points = res_tester.test.get_start_test_points()
@@ -99,9 +98,11 @@ def compare_belts_responses(gcmd, config, st_process: ShakeTuneProcess) -> None:
 
     # Run the test for each axis
     for config in filtered_config:
+        accelerometer = Accelerometer(printer.lookup_object(accel_chip))
         accelerometer.start_measurement()
         vibrate_axis(toolhead, gcode, config['direction'], min_freq, max_freq, hz_per_sec, accel_per_hz)
         accelerometer.stop_measurement(config['label'], append_time=True)
+        del accelerometer
 
     # Re-enable the input shaper if it was active
     if input_shaper is not None:

--- a/shaketune/commands/create_vibrations_profile.py
+++ b/shaketune/commands/create_vibrations_profile.py
@@ -90,7 +90,6 @@ def create_vibrations_profile(gcmd, config, st_process: ShakeTuneProcess) -> Non
         k_accelerometer = printer.lookup_object(current_accel_chip, None)
         if k_accelerometer is None:
             raise gcmd.error(f'Accelerometer [{current_accel_chip}] not found!')
-        accelerometer = Accelerometer(k_accelerometer)
         ConsoleOutput.print(f'Accelerometer chip used for this angle: [{current_accel_chip}]')
 
         # Sweep the speed range to record the vibrations at different speeds
@@ -121,12 +120,14 @@ def create_vibrations_profile(gcmd, config, st_process: ShakeTuneProcess) -> Non
                 movements = 2
 
             # Back and forth movements to record the vibrations at constant speed in both direction
+            accelerometer = Accelerometer(k_accelerometer)
             accelerometer.start_measurement()
             for _ in range(movements):
                 toolhead.move([mid_x + dX, mid_y + dY, z_height, E], curr_speed)
                 toolhead.move([mid_x - dX, mid_y - dY, z_height, E], curr_speed)
             name = f'vib_an{curr_angle:.2f}sp{curr_speed:.2f}'.replace('.', '_')
             accelerometer.stop_measurement(name)
+            del accelerometer
 
             toolhead.dwell(0.3)
             toolhead.wait_moves()

--- a/shaketune/commands/create_vibrations_profile.py
+++ b/shaketune/commands/create_vibrations_profile.py
@@ -91,6 +91,7 @@ def create_vibrations_profile(gcmd, config, st_process: ShakeTuneProcess) -> Non
         if k_accelerometer is None:
             raise gcmd.error(f'Accelerometer [{current_accel_chip}] not found!')
         ConsoleOutput.print(f'Accelerometer chip used for this angle: [{current_accel_chip}]')
+        accelerometer = Accelerometer(k_accelerometer)
 
         # Sweep the speed range to record the vibrations at different speeds
         for curr_speed_sample in range(nb_speed_samples):
@@ -120,17 +121,17 @@ def create_vibrations_profile(gcmd, config, st_process: ShakeTuneProcess) -> Non
                 movements = 2
 
             # Back and forth movements to record the vibrations at constant speed in both direction
-            accelerometer = Accelerometer(k_accelerometer)
             accelerometer.start_measurement()
             for _ in range(movements):
                 toolhead.move([mid_x + dX, mid_y + dY, z_height, E], curr_speed)
                 toolhead.move([mid_x - dX, mid_y - dY, z_height, E], curr_speed)
             name = f'vib_an{curr_angle:.2f}sp{curr_speed:.2f}'.replace('.', '_')
             accelerometer.stop_measurement(name)
-            del accelerometer
 
             toolhead.dwell(0.3)
             toolhead.wait_moves()
+
+        accelerometer.wait_for_file_writes()
 
     # Restore the previous acceleration values
     gcode.run_script_from_command(

--- a/shaketune/commands/excitate_axis_at_freq.py
+++ b/shaketune/commands/excitate_axis_at_freq.py
@@ -100,6 +100,7 @@ def excitate_axis_at_freq(gcmd, config, st_process: ShakeTuneProcess) -> None:
     # If the user wanted to create a graph, we stop the recording and generate it
     if create_graph:
         accelerometer.stop_measurement(f'staticfreq_{axis.upper()}', append_time=True)
+        del accelerometer
 
         creator = st_process.get_graph_creator()
         creator.configure(freq, duration, accel_per_hz)

--- a/shaketune/commands/excitate_axis_at_freq.py
+++ b/shaketune/commands/excitate_axis_at_freq.py
@@ -100,7 +100,7 @@ def excitate_axis_at_freq(gcmd, config, st_process: ShakeTuneProcess) -> None:
     # If the user wanted to create a graph, we stop the recording and generate it
     if create_graph:
         accelerometer.stop_measurement(f'staticfreq_{axis.upper()}', append_time=True)
-        del accelerometer
+        accelerometer.wait_for_file_writes()
 
         creator = st_process.get_graph_creator()
         creator.configure(freq, duration, accel_per_hz)

--- a/shaketune/shaketune.py
+++ b/shaketune/shaketune.py
@@ -117,29 +117,54 @@ class ShakeTune:
     def cmd_EXCITATE_AXIS_AT_FREQ(self, gcmd) -> None:
         ConsoleOutput.print(f'Shake&Tune version: {ShakeTuneConfig.get_git_version()}')
         static_freq_graph_creator = StaticGraphCreator(self._config)
-        st_process = ShakeTuneProcess(self._config, static_freq_graph_creator, self.timeout)
+        st_process = ShakeTuneProcess(
+            self._config,
+            self._printer.get_reactor(),
+            static_freq_graph_creator,
+            self.timeout,
+        )
         excitate_axis_at_freq(gcmd, self._pconfig, st_process)
 
     def cmd_AXES_MAP_CALIBRATION(self, gcmd) -> None:
         ConsoleOutput.print(f'Shake&Tune version: {ShakeTuneConfig.get_git_version()}')
         axes_map_graph_creator = AxesMapGraphCreator(self._config)
-        st_process = ShakeTuneProcess(self._config, axes_map_graph_creator, self.timeout)
+        st_process = ShakeTuneProcess(
+            self._config,
+            self._printer.get_reactor(),
+            axes_map_graph_creator,
+            self.timeout,
+        )
         axes_map_calibration(gcmd, self._pconfig, st_process)
 
     def cmd_COMPARE_BELTS_RESPONSES(self, gcmd) -> None:
         ConsoleOutput.print(f'Shake&Tune version: {ShakeTuneConfig.get_git_version()}')
         belt_graph_creator = BeltsGraphCreator(self._config)
-        st_process = ShakeTuneProcess(self._config, belt_graph_creator, self.timeout)
+        st_process = ShakeTuneProcess(
+            self._config,
+            self._printer.get_reactor(),
+            belt_graph_creator,
+            self.timeout,
+        )
         compare_belts_responses(gcmd, self._pconfig, st_process)
 
     def cmd_AXES_SHAPER_CALIBRATION(self, gcmd) -> None:
         ConsoleOutput.print(f'Shake&Tune version: {ShakeTuneConfig.get_git_version()}')
         shaper_graph_creator = ShaperGraphCreator(self._config)
-        st_process = ShakeTuneProcess(self._config, shaper_graph_creator, self.timeout)
+        st_process = ShakeTuneProcess(
+            self._config,
+            self._printer.get_reactor(),
+            shaper_graph_creator,
+            self.timeout,
+        )
         axes_shaper_calibration(gcmd, self._pconfig, st_process)
 
     def cmd_CREATE_VIBRATIONS_PROFILE(self, gcmd) -> None:
         ConsoleOutput.print(f'Shake&Tune version: {ShakeTuneConfig.get_git_version()}')
         vibration_profile_creator = VibrationsGraphCreator(self._config)
-        st_process = ShakeTuneProcess(self._config, vibration_profile_creator, self.timeout)
+        st_process = ShakeTuneProcess(
+            self._config,
+            self._printer.get_reactor(),
+            vibration_profile_creator,
+            self.timeout,
+        )
         create_vibrations_profile(gcmd, self._pconfig, st_process)

--- a/shaketune/shaketune_process.py
+++ b/shaketune/shaketune_process.py
@@ -52,7 +52,10 @@ class ShakeTuneProcess:
     # as a Timer in a thread INSIDE the Shake&Tune child process to not interfere with the main Klipper process
     def _shaketune_process_wrapper(self, graph_creator, timeout) -> None:
         if timeout is not None:
-            timer = threading.Timer(timeout + 5, self._handle_timeout)  # Add 5 seconds to the timeout for safety
+            # Add 5 seconds to the timeout for safety. The goal is to avoid the Timer to finish before the
+            # Shake&Tune process is done in case we call the wait_for_completion() function that uses Klipper's reactor.
+            timeout += 5
+            timer = threading.Timer(timeout, self._handle_timeout)
             timer.start()
         try:
             self._shaketune_process(graph_creator)

--- a/shaketune/shaketune_process.py
+++ b/shaketune/shaketune_process.py
@@ -8,10 +8,10 @@
 #              vibration analysis processes in separate system processes.
 
 
-import multiprocessing
 import os
 import threading
 import traceback
+from multiprocessing import Process
 from typing import Optional
 
 from .helpers.console_output import ConsoleOutput
@@ -31,9 +31,7 @@ class ShakeTuneProcess:
 
     def run(self) -> None:
         # Start the target function in a new process (a thread is known to cause issues with Klipper and CANbus due to the GIL)
-        self._process = multiprocessing.Process(
-            target=self._shaketune_process_wrapper, args=(self.graph_creator, self._timeout)
-        )
+        self._process = Process(target=self._shaketune_process_wrapper, args=(self.graph_creator, self._timeout))
         self._process.start()
 
     def wait_for_completion(self) -> None:

--- a/shaketune/shaketune_process.py
+++ b/shaketune/shaketune_process.py
@@ -58,10 +58,12 @@ class ShakeTuneProcess:
         os._exit(1)  # Forcefully exit the process
 
     def _shaketune_process(self, graph_creator) -> None:
-        # Trying to reduce Shake&Tune process priority to avoid slowing down the main Klipper process
-        # as this could lead to random "Timer too close" errors when already running CANbus, etc...
+        # Reducing Shake&Tune process priority by putting the scheduler into batch mode with low priority. This in order to avoid
+        # slowing down the main Klipper process as this can lead to random "Timer too close" or "Move queue overflow" errors
+        # when also already running CANbus, neopixels and other consumming stuff in Klipper's main process.
         try:
-            os.nice(19)
+            param = os.sched_param(os.sched_get_priority_min(os.SCHED_BATCH))
+            os.sched_setscheduler(0, os.SCHED_BATCH, param)
         except Exception:
             ConsoleOutput.print('Warning: failed reducing Shake&Tune process priority, continuing...')
 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses random 'Timer too close' and 'Move queue overflow' errors by adjusting process priority and improving timeout handling. It also enhances the reliability of file writing operations by introducing a queue and separate processes for writing accelerometer data, ensuring all file writes are completed before proceeding.

* **Bug Fixes**:
    - Fixed random 'Timer too close' and 'Move queue overflow' errors by adjusting process priority and timeout handling.
* **Enhancements**:
    - Introduced reactor-based timeout management in ShakeTuneProcess to improve reliability.
    - Added a queue and separate processes for writing accelerometer data to files to prevent blocking the main process.
    - Ensured all file writes are completed before proceeding by adding wait_for_file_writes method in Accelerometer class.

<!-- Generated by sourcery-ai[bot]: end summary -->