### PR TITLE
Compatibility with Klipper < v0.12.0-239

### DIFF
--- a/shaketune/commands/axes_shaper_calibration.py
+++ b/shaketune/commands/axes_shaper_calibration.py
@@ -76,8 +76,12 @@ def axes_shaper_calibration(gcmd, config, st_process: ShakeTuneProcess) -> None:
     # set the needed acceleration values for the test
     toolhead_info = toolhead.get_status(systime)
     old_accel = toolhead_info['max_accel']
-    old_mcr = toolhead_info['minimum_cruise_ratio']
-    gcode.run_script_from_command(f'SET_VELOCITY_LIMIT ACCEL={max_accel} MINIMUM_CRUISE_RATIO=0')
+    if 'minimum_cruise_ratio' in toolhead_info: # minimum_cruise_ratio found: Klipper >= v0.12.0-239
+        old_mcr = toolhead_info['minimum_cruise_ratio']
+        gcode.run_script_from_command(f'SET_VELOCITY_LIMIT ACCEL={max_accel} MINIMUM_CRUISE_RATIO=0')
+    else: # minimum_cruise_ratio not found: Klipper < v0.12.0-239
+        old_mcr = None
+        gcode.run_script_from_command(f'SET_VELOCITY_LIMIT ACCEL={max_accel}')
 
     # Deactivate input shaper if it is active to get raw movements
     input_shaper = printer.lookup_object('input_shaper', None)
@@ -115,6 +119,9 @@ def axes_shaper_calibration(gcmd, config, st_process: ShakeTuneProcess) -> None:
     # Re-enable the input shaper if it was active
     if input_shaper is not None:
         input_shaper.enable_shaping()
-
+    
     # Restore the previous acceleration values
-    gcode.run_script_from_command(f'SET_VELOCITY_LIMIT ACCEL={old_accel} MINIMUM_CRUISE_RATIO={old_mcr}')
+    if old_mcr is not None: # minimum_cruise_ratio found: Klipper >= v0.12.0-239
+        gcode.run_script_from_command(f'SET_VELOCITY_LIMIT ACCEL={old_accel} MINIMUM_CRUISE_RATIO={old_mcr}')
+    else: # minimum_cruise_ratio not found: Klipper < v0.12.0-239
+        gcode.run_script_from_command(f'SET_VELOCITY_LIMIT ACCEL={old_accel}')

--- a/shaketune/commands/compare_belts_responses.py
+++ b/shaketune/commands/compare_belts_responses.py
@@ -88,9 +88,13 @@ def compare_belts_responses(gcmd, config, st_process: ShakeTuneProcess) -> None:
 
     # set the needed acceleration values for the test
     toolhead_info = toolhead.get_status(systime)
-    old_accel = toolhead_info['max_accel']
-    old_mcr = toolhead_info['minimum_cruise_ratio']
-    gcode.run_script_from_command(f'SET_VELOCITY_LIMIT ACCEL={max_accel} MINIMUM_CRUISE_RATIO=0')
+    old_accel = toolhead_info['max_accel']    
+    if 'minimum_cruise_ratio' in toolhead_info: # minimum_cruise_ratio found: Klipper >= v0.12.0-239
+        old_mcr = toolhead_info['minimum_cruise_ratio']
+        gcode.run_script_from_command(f'SET_VELOCITY_LIMIT ACCEL={max_accel} MINIMUM_CRUISE_RATIO=0')
+    else: # minimum_cruise_ratio not found: Klipper < v0.12.0-239
+        old_mcr = None
+        gcode.run_script_from_command(f'SET_VELOCITY_LIMIT ACCEL={max_accel}')
 
     # Deactivate input shaper if it is active to get raw movements
     input_shaper = printer.lookup_object('input_shaper', None)
@@ -112,7 +116,10 @@ def compare_belts_responses(gcmd, config, st_process: ShakeTuneProcess) -> None:
         input_shaper.enable_shaping()
 
     # Restore the previous acceleration values
-    gcode.run_script_from_command(f'SET_VELOCITY_LIMIT ACCEL={old_accel} MINIMUM_CRUISE_RATIO={old_mcr}')
+    if old_mcr is not None: # minimum_cruise_ratio found: Klipper >= v0.12.0-239
+        gcode.run_script_from_command(f'SET_VELOCITY_LIMIT ACCEL={old_accel} MINIMUM_CRUISE_RATIO={old_mcr}')
+    else: # minimum_cruise_ratio not found: Klipper < v0.12.0-239
+        gcode.run_script_from_command(f'SET_VELOCITY_LIMIT ACCEL={old_accel}')
 
     # Run post-processing
     ConsoleOutput.print('Belts comparative frequency profile generation...')

--- a/shaketune/commands/create_vibrations_profile.py
+++ b/shaketune/commands/create_vibrations_profile.py
@@ -59,11 +59,15 @@ def create_vibrations_profile(gcmd, config, st_process: ShakeTuneProcess) -> Non
 
     toolhead_info = toolhead.get_status(systime)
     old_accel = toolhead_info['max_accel']
-    old_mcr = toolhead_info['minimum_cruise_ratio']
     old_sqv = toolhead_info['square_corner_velocity']
 
     # set the wanted acceleration values
-    gcode.run_script_from_command(f'SET_VELOCITY_LIMIT ACCEL={accel} MINIMUM_CRUISE_RATIO=0 SQUARE_CORNER_VELOCITY=5.0')
+    if 'minimum_cruise_ratio' in toolhead_info: # minimum_cruise_ratio found: Klipper >= v0.12.0-239
+        old_mcr = toolhead_info['minimum_cruise_ratio']    
+        gcode.run_script_from_command(f'SET_VELOCITY_LIMIT ACCEL={accel} MINIMUM_CRUISE_RATIO=0 SQUARE_CORNER_VELOCITY=5.0')
+    else: # minimum_cruise_ratio not found: Klipper < v0.12.0-239
+        old_mcr = None
+        gcode.run_script_from_command(f'SET_VELOCITY_LIMIT ACCEL={accel} SQUARE_CORNER_VELOCITY=5.0')
 
     kin_info = toolhead.kin.get_status(systime)
     mid_x = (kin_info['axis_minimum'].x + kin_info['axis_maximum'].x) / 2
@@ -134,9 +138,10 @@ def create_vibrations_profile(gcmd, config, st_process: ShakeTuneProcess) -> Non
         accelerometer.wait_for_file_writes()
 
     # Restore the previous acceleration values
-    gcode.run_script_from_command(
-        f'SET_VELOCITY_LIMIT ACCEL={old_accel} MINIMUM_CRUISE_RATIO={old_mcr} SQUARE_CORNER_VELOCITY={old_sqv}'
-    )
+    if old_mcr is not None: # minimum_cruise_ratio found: Klipper >= v0.12.0-239
+        gcode.run_script_from_command(f'SET_VELOCITY_LIMIT ACCEL={old_accel} MINIMUM_CRUISE_RATIO={old_mcr}')
+    else: # minimum_cruise_ratio not found: Klipper < v0.12.0-239
+        gcode.run_script_from_command(f'SET_VELOCITY_LIMIT ACCEL={old_accel}')
     toolhead.wait_moves()
 
     # Run post-processing

--- a/shaketune/commands/create_vibrations_profile.py
+++ b/shaketune/commands/create_vibrations_profile.py
@@ -137,11 +137,11 @@ def create_vibrations_profile(gcmd, config, st_process: ShakeTuneProcess) -> Non
 
         accelerometer.wait_for_file_writes()
 
-    # Restore the previous acceleration values
+        # Restore the previous acceleration values
     if old_mcr is not None: # minimum_cruise_ratio found: Klipper >= v0.12.0-239
-        gcode.run_script_from_command(f'SET_VELOCITY_LIMIT ACCEL={old_accel} MINIMUM_CRUISE_RATIO={old_mcr}')
+        gcode.run_script_from_command(f'SET_VELOCITY_LIMIT ACCEL={old_accel} MINIMUM_CRUISE_RATIO={old_mcr} SQUARE_CORNER_VELOCITY={old_sqv}')
     else: # minimum_cruise_ratio not found: Klipper < v0.12.0-239
-        gcode.run_script_from_command(f'SET_VELOCITY_LIMIT ACCEL={old_accel}')
+        gcode.run_script_from_command(f'SET_VELOCITY_LIMIT ACCEL={old_accel} SQUARE_CORNER_VELOCITY={old_sqv}')
     toolhead.wait_moves()
 
     # Run post-processing


### PR DESCRIPTION
The parameter _minimum_cruise_ratio_ doesn't exists on Klipper <  v0.12.0-239
See [Klipper Configuration Changes 20240313](https://github.com/Klipper3d/klipper/blob/master/docs/Config_Changes.md)

So, checking the presence of _minimum_cruise_ratio_ into _toolhead_info_ collection is necessary to maintain the compatibility with Klipper < v0.12.0-239

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request ensures compatibility with Klipper versions earlier than v0.12.0-239 by adding conditional checks for the 'minimum_cruise_ratio' parameter in various scripts. This prevents errors when the parameter is not present in older versions of Klipper.

- **Bug Fixes**:
    - Added checks for the presence of 'minimum_cruise_ratio' in toolhead_info to maintain compatibility with Klipper versions earlier than v0.12.0-239.

<!-- Generated by sourcery-ai[bot]: end summary -->