### PR TITLE
feat(ci): expand matrix accross python and klipper versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,18 @@ jobs:
         klipper_repo:
           - klipper3d/klipper
           - DangerKlippers/danger-klipper
+        klipper_version:
+          - master
+          - v0.12.0
+        python_version:
+          - '3.9' # Debian Bullseye default
+          - '3.11' # Debian Bookworm default
+          # Below disabled - Greenlet upstream version not compatable with py 3.12
+          # - '3.12' # Latest Released as of 2024/9
     steps: 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python_version }}
       - name: Checkout shaketune
         uses: actions/checkout@v4
         with:
@@ -23,7 +34,7 @@ jobs:
         with:
           path: klipper
           repository: ${{ matrix.klipper_repo }}
-          ref: master
+          ref: ${{ matrix.klipper_version }}
       - name: Install build dependencies
         run: |
           sudo apt-get update

--- a/MAINTNENCE.md
+++ b/MAINTNENCE.md
@@ -1,0 +1,7 @@
+## When a new stable version of klipper is released:
+
+In `.github/workflows/test.yaml`, update `jobs.klippy_testing.strategy.matrix.klipper_version` to include the new version.
+
+## When a new version of python becomes supported by klipper
+
+In `.github/workflows/test.yaml`, update `jobs.klippy_testing.strategy.matrix.python_version` to include the new version.


### PR DESCRIPTION
Expand existing matrix build to test on both latest Klipper, and v0.12.0 (the most recent release).
Also expand it to test on python 3.9 and 3.11, as they are the versions present in Debian bullseye and bookworm respectively.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Expand the CI workflow matrix to test across multiple Klipper versions and Python versions, enhancing compatibility checks with different environments.

CI:
- Expand the CI matrix to test against both the latest Klipper version and v0.12.0.
- Include Python 3.9 and 3.11 in the CI matrix to align with Debian Bullseye and Bookworm defaults.

<!-- Generated by sourcery-ai[bot]: end summary -->