### PR TITLE
allow newer versions of numpy, scipy and matplotlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 GitPython==3.1.41
-matplotlib==3.8.2
-numpy==1.26.2
-scipy==1.11.4
+matplotlib>=3.8.2
+numpy>=1.26.2
+scipy>=1.11.4
 PyWavelets==1.6.0
 zstandard==0.23.0


### PR DESCRIPTION
This PR allows already installed numpy, scipy and matplotlib versions not to be downgraded when shaketune is installed/updated.

Kalico has been running numpy>2 for some time now, and Klipper doesn't include these libraries in its requirements, so it should be safe enough.

## Summary by Sourcery

Relax numpy, scipy, and matplotlib version requirements. Allow installations of these libraries to be newer than the versions previously specified.