### PR TITLE
Accept float frequency in static freq test

### DIFF
--- a/shaketune/commands/excitate_axis_at_freq.py
+++ b/shaketune/commands/excitate_axis_at_freq.py
@@ -21,7 +21,7 @@ def excitate_axis_at_freq(gcmd, config, st_process: ShakeTuneProcess) -> None:
     date = datetime.now().strftime('%Y%m%d_%H%M%S')
 
     create_graph = gcmd.get_int('CREATE_GRAPH', default=0, minval=0, maxval=1) == 1
-    freq = gcmd.get_int('FREQUENCY', default=25, minval=1)
+    freq = gcmd.get_float('FREQUENCY', default=25, minval=1)
     duration = gcmd.get_int('DURATION', default=30, minval=1)
     accel_per_hz = gcmd.get_float('ACCEL_PER_HZ', default=None)
     axis = gcmd.get('AXIS', default='x').lower()

--- a/shaketune/commands/excitate_axis_at_freq.py
+++ b/shaketune/commands/excitate_axis_at_freq.py
@@ -53,7 +53,7 @@ def excitate_axis_at_freq(gcmd, config, st_process: ShakeTuneProcess) -> None:
             st_process.get_st_config().chunk_size, printer.get_reactor(), filename
         )
 
-    ConsoleOutput.print(f'Excitating {axis.upper()} axis at {freq}Hz for {duration} seconds')
+    ConsoleOutput.print(f'Excitating {axis.upper()} axis at {freq:.1f}Hz for {duration} seconds')
 
     printer = config.get_printer()
     gcode = printer.lookup_object('gcode')

--- a/shaketune/helpers/resonance_test.py
+++ b/shaketune/helpers/resonance_test.py
@@ -277,7 +277,7 @@ class ResonanceTestManager:
                 toolhead.move([nX, nY, nZ, E], max(abs_v, abs_last_v))
 
             if math.floor(freq) > math.floor(last_freq):
-                ConsoleOutput.print(f'Testing frequency: {freq:.0f} Hz')
+                ConsoleOutput.print(f'Testing frequency: {freq:.1f} Hz')
                 reactor.pause(reactor.monotonic() + 0.01)
 
             X, Y, Z = nX, nY, nZ


### PR DESCRIPTION
## Summary by Sourcery

Accept float values for frequency input in the excitate_axis_at_freq function and update console output to reflect this precision.

Enhancements:
- Allow frequency to be specified as a float in the excitate_axis_at_freq function, providing more precision for frequency input.
- Update console output to display frequency with one decimal place in both excitate_axis_at_freq and _run_test_sequence functions.