### PR TITLE
Add frequency values to peak annotations in visualization graphs

### DIFF
--- a/shaketune/graph_creators/plotter.py
+++ b/shaketune/graph_creators/plotter.py
@@ -787,7 +787,7 @@ class Plotter:
         for idx, peak in enumerate(peaks_freqs):
             ax_2.axvline(peak, color='cyan', linestyle='dotted', linewidth=1)
             ax_2.annotate(
-                f'Peak {idx + 1}',
+                f'Peak {idx + 1} ({peak:.1f} Hz)',
                 (peak, bins[-1] * 0.9),
                 textcoords='data',
                 color='cyan',
@@ -1202,7 +1202,7 @@ class Plotter:
             for idx, peak in enumerate(vibration_peaks):
                 ax_5.axvline(all_speeds[peak], color='cyan', linewidth=0.75)
                 ax_5.annotate(
-                    f'Peak {idx + 1}',
+                    f'Peak {idx + 1} ({peak:.1f} Hz)',
                     (all_speeds[peak], all_angles[-1] * 0.9),
                     textcoords='data',
                     color='cyan',


### PR DESCRIPTION
This PR enhances the readability of the Shaketune visualization graphs by adding the actual frequency values (in Hz) to peak annotations. These changes affect both the input shaper calibration and vibrations profile graphs, making it easier for users to identify specific resonance frequencies without having to estimate values from the graph axes.

Affected commands:
- AXES_SHAPER_CALIBRATION
- CREATE_VIBRATIONS_PROFILE

![image](https://github.com/user-attachments/assets/c31398a5-fbb8-4913-96d4-bf317b9baf65)
![image](https://github.com/user-attachments/assets/15aa84af-ef1e-406d-96ff-11b2b5ae9146)

## Summary by Sourcery

Enhancements:
- Add frequency values (in Hz) to peak annotations in input shaper calibration and vibrations profile graphs to enhance readability