### PR TITLE
Fix where 'ACCEL_CHIP' required double quoting

### DIFF
--- a/shaketune/dummy_macros.cfg
+++ b/shaketune/dummy_macros.cfg
@@ -19,17 +19,16 @@ gcode:
     {% set travel_speed = params.TRAVEL_SPEED|default(120) %}
     {% set z_height = params.Z_HEIGHT %}
     {% set accel_chip = params.ACCEL_CHIP %}
-    {% set params_filtered = {
+    {% set _ = params.update({
         "CREATE_GRAPH": create_graph,
         "FREQUENCY": frequency,
         "DURATION": duration,
-        "ACCEL_PER_HZ": accel_per_hz if accel_per_hz is not none else '',
         "AXIS": axis,
         "TRAVEL_SPEED": travel_speed,
-        "Z_HEIGHT": z_height if z_height is not none else '',
-        "ACCEL_CHIP": accel_chip if accel_chip is not none else ''
-    } %}
-    _EXCITATE_AXIS_AT_FREQ {% for key, value in params_filtered.items() if value is defined and value is not none and value != '' %}{key}={value} {% endfor %}
+    }) %}
+    _EXCITATE_AXIS_AT_FREQ {params|xmlattr}
+
+
 
 
 [gcode_macro AXES_MAP_CALIBRATION]
@@ -53,17 +52,11 @@ gcode:
     {% set z_height = params.Z_HEIGHT %}
     {% set max_scale = params.MAX_SCALE %}
     {% set accel_chip = params.ACCEL_CHIP %}
-    {% set params_filtered = {
-        "FREQ_START": freq_start if freq_start is not none else '',
-        "FREQ_END": freq_end if freq_end is not none else '',
+    {% set _ = params.update({
         "HZ_PER_SEC": hz_per_sec,
-        "ACCEL_PER_HZ": accel_per_hz if accel_per_hz is not none else '',
         "TRAVEL_SPEED": travel_speed,
-        "Z_HEIGHT": z_height if z_height is not none else '',
-        "MAX_SCALE": max_scale if max_scale is not none else '',
-        "ACCEL_CHIP": accel_chip if accel_chip is not none else ''
-    } %}
-    _COMPARE_BELTS_RESPONSES {% for key, value in params_filtered.items() if value is defined and value is not none and value != '' %}{key}={value} {% endfor %}
+    }) %}
+    _COMPARE_BELTS_RESPONSES {params|xmlattr}
 
 
 [gcode_macro AXES_SHAPER_CALIBRATION]
@@ -80,20 +73,12 @@ gcode:
     {% set z_height = params.Z_HEIGHT %}
     {% set max_scale = params.MAX_SCALE %}
     {% set accel_chip = params.ACCEL_CHIP %}
-    {% set params_filtered = {
-        "FREQ_START": freq_start if freq_start is not none else '',
-        "FREQ_END": freq_end if freq_end is not none else '',
+    {% set _ = params.update({
         "HZ_PER_SEC": hz_per_sec,
-        "ACCEL_PER_HZ": accel_per_hz if accel_per_hz is not none else '',
         "AXIS": axis,
-        "SCV": scv if scv is not none else '',
-        "MAX_SMOOTHING": max_smoothing if max_smoothing is not none else '',
         "TRAVEL_SPEED": travel_speed,
-        "Z_HEIGHT": z_height if z_height is not none else '',
-        "MAX_SCALE": max_scale if max_scale is not none else '',
-        "ACCEL_CHIP": accel_chip if accel_chip is not none else ''
-    } %}
-    _AXES_SHAPER_CALIBRATION {% for key, value in params_filtered.items() if value is defined and value is not none and value != '' %}{key}={value} {% endfor %}
+    }) %}
+    _AXES_SHAPER_CALIBRATION {params|xmlattr}
 
 
 [gcode_macro CREATE_VIBRATIONS_PROFILE]


### PR DESCRIPTION
possible fix for [issue ticket #234](https://github.com/Frix-x/klippain-shaketune/issues/234#issue-3370939310)

## Summary by Sourcery

Update Shaketune dummy_macros.cfg to simplify parameter handling in gcode macros by using params.update and xmlattr filter, fixing ACCEL_CHIP quoting issue

Bug Fixes:
- Ensure ACCEL_CHIP parameter is properly quoted in generated gcode macros

Enhancements:
- Refactor template macros to update params inline and render attributes using xmlattr filter instead of manual filtering loops