### PR TITLE
improved dummy macros handling of spaces in parameters strings values

### DIFF
--- a/shaketune/dummy_macros.cfg
+++ b/shaketune/dummy_macros.cfg
@@ -11,29 +11,17 @@
 [gcode_macro EXCITATE_AXIS_AT_FREQ]
 description: dummy
 gcode:
-    {% set create_graph = params.CREATE_GRAPH|default(0) %}
-    {% set frequency = params.FREQUENCY|default(25) %}
-    {% set duration = params.DURATION|default(30) %}
-    {% set accel_per_hz = params.ACCEL_PER_HZ %}
-    {% set axis = params.AXIS|default('x') %}
-    {% set travel_speed = params.TRAVEL_SPEED|default(120) %}
-    {% set x_pos = params.X_POS %}
-    {% set y_pos = params.Y_POS %}
-    {% set z_height = params.Z_HEIGHT %}
-    {% set accel_chip = params.ACCEL_CHIP %}
-    {% set params_filtered = {
-        "CREATE_GRAPH": create_graph,
-        "FREQUENCY": frequency,
-        "DURATION": duration,
-        "ACCEL_PER_HZ": accel_per_hz if accel_per_hz is not none else '',
-        "AXIS": axis,
-        "TRAVEL_SPEED": travel_speed,
-        "X_POS": x_pos if x_pos is not none else '',
-        "Y_POS": y_pos if y_pos is not none else '',
-        "Z_HEIGHT": z_height if z_height is not none else '',
-        "ACCEL_CHIP": accel_chip if accel_chip is not none else ''
-    } %}
-    _EXCITATE_AXIS_AT_FREQ {% for key, value in params_filtered.items() if value is defined and value is not none and value != '' %}{key}={value} {% endfor %}
+    {% set dummy = params.CREATE_GRAPH|default(0) %}
+    {% set dummy = params.FREQUENCY|default(25) %}
+    {% set dummy = params.DURATION|default(30) %}
+    {% set dummy = params.ACCEL_PER_HZ %}
+    {% set dummy = params.AXIS|default('x') %}
+    {% set dummy = params.TRAVEL_SPEED|default(120) %}
+    {% set dummy = params.X_POS %}
+    {% set dummy = params.Y_POS %}
+    {% set dummy = params.Z_HEIGHT %}
+    {% set dummy = params.ACCEL_CHIP %}
+    _EXCITATE_AXIS_AT_FREQ {% for key, value in params.items() if value is not none and value != '' %}{key}="{value}" {% endfor %}
 
 
 [gcode_macro AXES_MAP_CALIBRATION]
@@ -43,61 +31,38 @@ gcode:
     {% set dummy = params.SPEED|default(80) %}
     {% set dummy = params.ACCEL|default(1500) %}
     {% set dummy = params.TRAVEL_SPEED|default(120) %}
-    _AXES_MAP_CALIBRATION {rawparams}
+    _AXES_MAP_CALIBRATION {% for key, value in params.items() if value is not none and value != '' %}{key}="{value}" {% endfor %}
 
 
 [gcode_macro COMPARE_BELTS_RESPONSES]
 description: dummy
 gcode:
-    {% set freq_start = params.FREQ_START %}
-    {% set freq_end = params.FREQ_END %}
-    {% set hz_per_sec = params.HZ_PER_SEC|default(1) %}
-    {% set accel_per_hz = params.ACCEL_PER_HZ %}
-    {% set travel_speed = params.TRAVEL_SPEED|default(120) %}
-    {% set z_height = params.Z_HEIGHT %}
-    {% set max_scale = params.MAX_SCALE %}
-    {% set accel_chip = params.ACCEL_CHIP %}
-    {% set params_filtered = {
-        "FREQ_START": freq_start if freq_start is not none else '',
-        "FREQ_END": freq_end if freq_end is not none else '',
-        "HZ_PER_SEC": hz_per_sec,
-        "ACCEL_PER_HZ": accel_per_hz if accel_per_hz is not none else '',
-        "TRAVEL_SPEED": travel_speed,
-        "Z_HEIGHT": z_height if z_height is not none else '',
-        "MAX_SCALE": max_scale if max_scale is not none else '',
-        "ACCEL_CHIP": accel_chip if accel_chip is not none else ''
-    } %}
-    _COMPARE_BELTS_RESPONSES {% for key, value in params_filtered.items() if value is defined and value is not none and value != '' %}{key}={value} {% endfor %}
+    {% set dummy = params.FREQ_START %}
+    {% set dummy = params.FREQ_END %}
+    {% set dummy = params.HZ_PER_SEC|default(1) %}
+    {% set dummy = params.ACCEL_PER_HZ %}
+    {% set dummy = params.TRAVEL_SPEED|default(120) %}
+    {% set dummy = params.Z_HEIGHT %}
+    {% set dummy = params.MAX_SCALE %}
+    {% set dummy = params.ACCEL_CHIP %}
+    _COMPARE_BELTS_RESPONSES {% for key, value in params.items() if value is not none and value != '' %}{key}="{value}" {% endfor %}
 
 
 [gcode_macro AXES_SHAPER_CALIBRATION]
 description: dummy
 gcode:
-    {% set freq_start = params.FREQ_START %}
-    {% set freq_end = params.FREQ_END %}
-    {% set hz_per_sec = params.HZ_PER_SEC|default(1) %}
-    {% set accel_per_hz = params.ACCEL_PER_HZ %}
-    {% set axis = params.AXIS|default('all') %}
-    {% set scv = params.SCV %}
-    {% set max_smoothing = params.MAX_SMOOTHING %}
-    {% set travel_speed = params.TRAVEL_SPEED|default(120) %}
-    {% set z_height = params.Z_HEIGHT %}
-    {% set max_scale = params.MAX_SCALE %}
-    {% set accel_chip = params.ACCEL_CHIP %}
-    {% set params_filtered = {
-        "FREQ_START": freq_start if freq_start is not none else '',
-        "FREQ_END": freq_end if freq_end is not none else '',
-        "HZ_PER_SEC": hz_per_sec,
-        "ACCEL_PER_HZ": accel_per_hz if accel_per_hz is not none else '',
-        "AXIS": axis,
-        "SCV": scv if scv is not none else '',
-        "MAX_SMOOTHING": max_smoothing if max_smoothing is not none else '',
-        "TRAVEL_SPEED": travel_speed,
-        "Z_HEIGHT": z_height if z_height is not none else '',
-        "MAX_SCALE": max_scale if max_scale is not none else '',
-        "ACCEL_CHIP": accel_chip if accel_chip is not none else ''
-    } %}
-    _AXES_SHAPER_CALIBRATION {% for key, value in params_filtered.items() if value is defined and value is not none and value != '' %}{key}={value} {% endfor %}
+    {% set dummy = params.FREQ_START %}
+    {% set dummy = params.FREQ_END %}
+    {% set dummy = params.HZ_PER_SEC|default(1) %}
+    {% set dummy = params.ACCEL_PER_HZ %}
+    {% set dummy = params.AXIS|default('all') %}
+    {% set dummy = params.SCV %}
+    {% set dummy = params.MAX_SMOOTHING %}
+    {% set dummy = params.TRAVEL_SPEED|default(120) %}
+    {% set dummy = params.Z_HEIGHT %}
+    {% set dummy = params.MAX_SCALE %}
+    {% set dummy = params.ACCEL_CHIP %}
+    _AXES_SHAPER_CALIBRATION {% for key, value in params.items() if value is not none and value != '' %}{key}="{value}" {% endfor %}
 
 
 [gcode_macro CREATE_VIBRATIONS_PROFILE]
@@ -111,4 +76,4 @@ gcode:
     {% set dummy = params.ACCEL|default(3000) %}
     {% set dummy = params.TRAVEL_SPEED|default(120) %}
     {% set dummy = params.ACCEL_CHIP %}
-    _CREATE_VIBRATIONS_PROFILE {rawparams}
+    _CREATE_VIBRATIONS_PROFILE {% for key, value in params.items() if value is not none and value != '' %}{key}="{value}" {% endfor %}


### PR DESCRIPTION
Improve dummy macros parameter handling by removing empty-string fallbacks and applying xmlattr filtering to properly quote and escape values with spaces.

Enhancements:
- Remove empty-string fallback logic for None macro parameters across dummy macros
- Apply xmlattr filter to macro parameter outputs for proper quoting and escaping of values containing spaces

## Summary by Sourcery

Standardize dummy macro parameter forwarding to underlying macros while preserving default values and properly quoting non-empty arguments.

Bug Fixes:
- Ensure dummy macros correctly pass through parameters containing spaces by quoting non-empty argument values instead of dropping them or relying on empty-string fallbacks.

Enhancements:
- Simplify dummy macro implementations by removing custom filtered parameter maps and using a generic loop over provided parameters for command forwarding across all macros.