### PR TITLE
Bye, Bye, Bye (SciPy)

### DIFF
--- a/docs/cli_usage.md
+++ b/docs/cli_usage.md
@@ -7,7 +7,7 @@ Shake&Tune includes a command-line interface (CLI) that allows you to generate g
 The CLI mode uses the same dependencies as the main Shake&Tune plugin. Ensure you have:
 
 - Python 3.9 or newer
-- Required Python packages: `numpy`, `matplotlib`, `scipy`, `zstandard`
+- Required Python packages: `numpy`, `matplotlib`, `zstandard`
 - The Klipper repository cloned locally in your home folder (no need to install it, just clone it)
 
 You can install these dependencies using:

--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,7 @@ function is_package_installed {
 }
 
 function install_package_requirements {
-    packages=("libopenblas-dev" "libatlas-base-dev")
+    packages=("libopenblas-dev")
     packages_to_install=""
 
     for package in "${packages[@]}"; do

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 GitPython==3.1.41
-matplotlib==3.8.2
-numpy==1.26.2
-scipy==1.11.4
+matplotlib==3.9.4
+numpy==2.0.2 ; python_full_version < '3.10'
+numpy==2.2.2 ; python_full_version >= '3.10'
 PyWavelets==1.6.0
 zstandard==0.23.0

--- a/shaketune/graph_creators/computations/axes_map_computation.py
+++ b/shaketune/graph_creators/computations/axes_map_computation.py
@@ -10,7 +10,7 @@ from typing import List, Tuple
 
 import numpy as np
 import pywt
-from scipy import stats
+from numpy.polynomial.polynomial import Polynomial
 
 from ...helpers.accelerometer import Measurement
 from ...helpers.console_output import ConsoleOutput
@@ -232,9 +232,9 @@ class AxesMapComputation:
 
         # Compute the direction vector using linear regression over the position data
         time = np.arange(len(position_x))
-        slope_x, intercept_x, _, _, _ = stats.linregress(time, position_x)
-        slope_y, intercept_y, _, _, _ = stats.linregress(time, position_y)
-        slope_z, intercept_z, _, _, _ = stats.linregress(time, position_z)
+        intercept_x, slope_x, *_ = Polynomial.fit(time, position_x, 1).convert()
+        intercept_y, slope_y, *_ = Polynomial.fit(time, position_y, 1).convert()
+        intercept_z, slope_z, *_ = Polynomial.fit(time, position_z, 1).convert()
 
         end_position = np.array(
             [slope_x * time[-1] + intercept_x, slope_y * time[-1] + intercept_y, slope_z * time[-1] + intercept_z]

--- a/shaketune/graph_creators/computations/belts_computation.py
+++ b/shaketune/graph_creators/computations/belts_computation.py
@@ -9,7 +9,6 @@
 from typing import Any, List, NamedTuple, Optional, Tuple
 
 import numpy as np
-from scipy.stats import pearsonr
 
 from ...helpers.accelerometer import Measurement
 from ...helpers.common_func import detect_peaks
@@ -96,7 +95,7 @@ class BeltsComputation:
         similarity_factor = None
         mhi = None
         if self.kinematics in {'limited_corexy', 'corexy', 'limited_corexz', 'corexz'}:
-            correlation, _ = pearsonr(signal1.psd, signal2.psd)
+            correlation = np.corrcoef(signal1.psd, signal2.psd)[0][-1]
             similarity_factor = correlation * 100
             similarity_factor = np.clip(similarity_factor, 0, 100)
             ConsoleOutput.print(f'Belts estimated similarity: {similarity_factor:.1f}%')

--- a/shaketune/graph_creators/computations/shaper_computation.py
+++ b/shaketune/graph_creators/computations/shaper_computation.py
@@ -11,8 +11,9 @@ from typing import Any, List, Optional
 import numpy as np
 
 from ...helpers.accelerometer import Measurement
-from ...helpers.common_func import compute_mechanical_parameters, compute_spectrogram, detect_peaks
+from ...helpers.common_func import compute_mechanical_parameters, detect_peaks
 from ...helpers.console_output import ConsoleOutput
+from ...helpers.spectrogram import compute_spectrogram
 from .. import get_shaper_calibrate_module
 from ..base_models import GraphMetadata
 from ..computation_results import ShaperResult

--- a/shaketune/graph_creators/computations/static_frequency_computation.py
+++ b/shaketune/graph_creators/computations/static_frequency_computation.py
@@ -11,7 +11,7 @@ from typing import List, Optional
 import numpy as np
 
 from ...helpers.accelerometer import Measurement
-from ...helpers.common_func import compute_spectrogram
+from ...helpers.spectrogram import compute_spectrogram
 from ...helpers.console_output import ConsoleOutput
 from ..base_models import GraphMetadata
 from ..computation_results import StaticFrequencyResult

--- a/shaketune/helpers/common_func.py
+++ b/shaketune/helpers/common_func.py
@@ -15,7 +15,6 @@ from importlib import import_module
 from pathlib import Path
 
 import numpy as np
-from scipy.signal import spectrogram
 
 # Constant used to define the standard axis direction and names
 AXIS_CONFIG = [
@@ -55,27 +54,6 @@ def get_git_version():
 
     except Exception:
         return None
-
-
-# This is Klipper's spectrogram generation function adapted to use Scipy
-def compute_spectrogram(data):
-    N = data.shape[0]
-    Fs = N / (data[-1, 0] - data[0, 0])
-    # Round up to a power of 2 for faster FFT
-    M = 1 << int(0.5 * Fs - 1).bit_length()
-    window = np.kaiser(M, 6.0)
-
-    def _specgram(x):
-        return spectrogram(
-            x, fs=Fs, window=window, nperseg=M, noverlap=M // 2, detrend='constant', scaling='density', mode='psd'
-        )
-
-    d = {'x': data[:, 1], 'y': data[:, 2], 'z': data[:, 3]}
-    f, t, pdata = _specgram(d['x'])
-    for axis in 'yz':
-        pdata += _specgram(d[axis])[2]
-    return pdata, t, f
-
 
 # Compute natural resonant frequency and damping ratio by using the half power bandwidth method with interpolated frequencies
 def compute_mechanical_parameters(psd, freqs, min_freq=None):

--- a/shaketune/helpers/spectrogram.py
+++ b/shaketune/helpers/spectrogram.py
@@ -1,0 +1,118 @@
+import typing as t
+from functools import partial
+
+import numpy as np
+import numpy.typing as npt
+
+
+def _detrend_constant(data: npt.NDArray[np.float64]) -> npt.NDArray[np.floating[t.Any]]:
+    dtype = data.dtype.char
+    if dtype not in 'dfDF':
+        dtype = 'd'
+
+    return data - np.mean(data, axis=-1, keepdims=True)
+
+
+def _fft_helper(
+    x: npt.NDArray[np.float64],
+    window: npt.NDArray[np.float64],
+    nperseg: int,
+    noverlap: int,
+    nfft: int,
+    sides: str,
+) -> npt.NDArray[np.complex128]:
+    if nperseg == 1 and noverlap == 0:
+        result = x[..., np.newaxis]
+    else:
+        # https://stackoverflow.com/a/5568169
+        step = nperseg - noverlap
+        shape = x.shape[:-1] + ((x.shape[-1] - noverlap) // step, nperseg)
+        strides = x.strides[:-1] + (step * x.strides[-1], x.strides[-1])
+        result = np.lib.stride_tricks.as_strided(x, shape=shape, strides=strides)
+
+    # Detrend each data segment individually
+    result = _detrend_constant(result)
+
+    # Apply window by multiplication
+    result = window * result
+
+    if sides == 'twosided':
+        result = np.fft.fft(result, n=nfft)
+    else:
+        result = np.fft.rfft(result.real, n=nfft)
+
+    return result
+
+
+def spectrogram(x: npt.ArrayLike, fs: float, window: npt.NDArray[np.floating[t.Any]], nperseg: int, noverlap: int):
+    axis: int = -1
+    # Ensure we have np.arrays, get outdtype
+    x = np.asarray(x)
+    outdtype = np.result_type(x, np.complex64)
+
+    # Early return
+    if x.size == 0:
+        return np.empty(x.shape), np.empty(x.shape), np.empty(x.shape)
+
+    if np.result_type(window, np.complex64) != outdtype:
+        window = window.astype(outdtype)
+
+    if noverlap >= nperseg:
+        raise ValueError('noverlap must be less than nperseg.')
+
+    nfft = nperseg
+    scale = 1.0 / (fs * (window * window).sum())
+
+    if np.iscomplexobj(x):
+        sides = 'twosided'
+        freqs = np.fft.fftfreq(nfft, 1 / fs)
+    else:
+        sides = 'onesided'
+        freqs = np.fft.rfftfreq(nfft, 1 / fs)
+
+    # Perform the windowed FFTs
+    result = _fft_helper(x, window, nperseg, noverlap, nfft, sides)
+
+    # PSD
+    result = np.conjugate(result) * result
+    result *= scale
+
+    if sides == 'onesided':
+        if nfft % 2:
+            result[..., 1:] *= 2
+        else:
+            # Last point is unpaired Nyquist freq point, don't double
+            result[..., 1:-1] *= 2
+
+    time = np.arange(nperseg / 2, x.shape[-1] - nperseg / 2 + 1, nperseg - noverlap) / fs
+
+    result = result.astype(outdtype)
+
+    # All imaginary parts are zero anyways
+    result = result.real
+
+    # Roll frequency axis back to axis where the data came from
+    result = np.moveaxis(result, -1, axis - 1)
+
+    return freqs, time, result
+
+
+# This is Klipper's spectrogram generation function adapted to use Scipy
+def compute_spectrogram(
+    data: npt.NDArray[np.floating[t.Any]],
+) -> t.Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+    # Sampling frequency
+    fs = data.shape[0] / (data[-1, 0] - data[0, 0])
+    # Round up to a power of 2 for faster FFT
+    nperseg = 1 << int(0.5 * fs - 1).bit_length()
+    # Calculate Kaiser window
+    window = np.kaiser(nperseg, 6.0)
+
+    # Spectrogram helper
+    _specgram = partial(spectrogram, fs=fs, window=window, nperseg=nperseg, noverlap=nperseg // 2)
+
+    f, t, pdata = _specgram(data[:, 1])
+    for axis in range(2):
+        pdata += _specgram(data[:, axis + 2])[2]
+
+    return pdata.astype(np.float64), t, f


### PR DESCRIPTION
Replace SciPy functionality with NumPy equivalents to escape dependency hell.

libatlas is a dependency for installing precompiled SciPy packages for python, but the latest Raspbian/Debian 13 no longer have that package.
Instead of requiring the heavy SciPy dependency replace the functionality with direct NumPy calls / a little bit of wrapper code.

- **refactor: Replace SciPy pearsonr correlation coefficent with NumPy functionality**
- **refactor: Use numpy for linear regression calculations**
- **refactor: Replace scipy.spectrogram with numpy fft**
- **refactor: Bump numpy version, remove scipy dependency**
- **refactor: Stop installing scipy sytem dependencies**
- **docs: Remove scipy from list of dependencies**

## Summary by Sourcery

Remove SciPy dependency by reimplementing correlation, regression, and spectrogram functionality with pure NumPy, update dependency versions and installation scripts, and clean up documentation accordingly

Enhancements:
- Replace Pearson correlation using SciPy with NumPy's corrcoef
- Replace linear regression using SciPy stats with NumPy polynomial fitting
- Implement FFT-based spectrogram using NumPy in a new helper module instead of SciPy signal
- Remove installation of SciPy and related system libraries (libatlas, libopenblas)

Build:
- Bump NumPy version constraints and drop SciPy from requirements.txt

Documentation:
- Remove SciPy from the list of dependencies in documentation