### PR TITLE
Make S&T compatible with `uv`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
 ]
 keywords = ["klipper", "input shaper", "calibration", "3d printer"]
 license = {file = "LICENSE"}
+dynamic = ["version"]
 
 [project.urls]
 Repository = "https://github.com/Frix-x/klippain-shaketune"


### PR DESCRIPTION
Declare the project version in pyproject.toml to be externally set/defined to make the project compatible with `uv` (Python package and project manager).
