### PR TITLE
feat: Add `ACCEL_CHIP` parameter to axes map calibration

### DIFF
--- a/docs/macros/axes_map_calibration.md
+++ b/docs/macros/axes_map_calibration.md
@@ -17,6 +17,7 @@ Call the `AXES_MAP_CALIBRATION` macro and look for the graphs in the results fol
 |SPEED|80|speed of the toolhead in mm/s for the movements|
 |ACCEL|1500 (or max printer accel)|accel in mm/s^2 used for all the moves|
 |TRAVEL_SPEED|120|speed in mm/s used for all the travels moves|
+|ACCEL_CHIP|None|accelerometer chip you want to use for the test. If not provided, the macro will automatically find the best accelerometer chip based on your `[resonance_tester]` config section|
 
   > **Note**:
   >

--- a/shaketune/commands/axes_map_calibration.py
+++ b/shaketune/commands/axes_map_calibration.py
@@ -26,13 +26,19 @@ def axes_map_calibration(gcmd, config, st_process: ShakeTuneProcess) -> None:
     feedrate_travel = gcmd.get_float('TRAVEL_SPEED', default=120.0, minval=20.0)
     accel_chip = gcmd.get('ACCEL_CHIP', default=None)
 
+    if accel_chip == '':
+        accel_chip = None
+
     printer = config.get_printer()
     gcode = printer.lookup_object('gcode')
     toolhead = printer.lookup_object('toolhead')
     systime = printer.get_reactor().monotonic()
 
-    if not accel_chip:
+    current_accel_chip = accel_chip
+    if current_accel_chip is None:
         accel_chip = Accelerometer.find_axis_accelerometer(printer, 'xy')
+    if current_accel_chip is None:
+            raise gcmd.error('No suitable accelerometer found for measurement!')
     k_accelerometer = printer.lookup_object(accel_chip, None)
     if k_accelerometer is None:
         raise gcmd.error('Multi-accelerometer configurations are not supported for this macro!')

--- a/shaketune/commands/axes_map_calibration.py
+++ b/shaketune/commands/axes_map_calibration.py
@@ -24,13 +24,15 @@ def axes_map_calibration(gcmd, config, st_process: ShakeTuneProcess) -> None:
     speed = gcmd.get_float('SPEED', default=80.0, minval=20.0)
     accel = gcmd.get_int('ACCEL', default=1500, minval=100)
     feedrate_travel = gcmd.get_float('TRAVEL_SPEED', default=120.0, minval=20.0)
+    accel_chip = gcmd.get('ACCEL_CHIP', default=None)
 
     printer = config.get_printer()
     gcode = printer.lookup_object('gcode')
     toolhead = printer.lookup_object('toolhead')
     systime = printer.get_reactor().monotonic()
 
-    accel_chip = Accelerometer.find_axis_accelerometer(printer, 'xy')
+    if not accel_chip:
+        accel_chip = Accelerometer.find_axis_accelerometer(printer, 'xy')
     k_accelerometer = printer.lookup_object(accel_chip, None)
     if k_accelerometer is None:
         raise gcmd.error('Multi-accelerometer configurations are not supported for this macro!')


### PR DESCRIPTION
This PR adds support for the `ACCEL_CHIP` parameter for axes map calibration.

## Summary by Sourcery

Allow explicit selection of the accelerometer chip in axes map calibration via the new ACCEL_CHIP parameter while preserving automatic chip detection when the parameter is omitted.

New Features:
- Add optional ACCEL_CHIP parameter to the axes_map_calibration macro to allow users to specify the accelerometer chip

Documentation:
- Document the ACCEL_CHIP parameter and its default automatic detection behavior in the axes_map_calibration macro