### PR TITLE
Add name parameter to process_accelerometer_data calls

### DIFF
--- a/shaketune/graph_creators/computations/belts_computation.py
+++ b/shaketune/graph_creators/computations/belts_computation.py
@@ -132,7 +132,7 @@ class BeltsComputation:
     def _compute_signal_data(self, data: np.ndarray, common_freqs: np.ndarray, max_freq: float) -> SignalData:
         """Compute signal data from raw measurements"""
         shaper_calibrate, _ = get_shaper_calibrate_module()
-        calibration_data = shaper_calibrate.process_accelerometer_data(data)
+        calibration_data = shaper_calibrate.process_accelerometer_data(None, data)
 
         freqs = calibration_data.freq_bins[calibration_data.freq_bins <= max_freq]
         psd = calibration_data.get_psd('all')[calibration_data.freq_bins <= max_freq]

--- a/shaketune/graph_creators/computations/shaper_computation.py
+++ b/shaketune/graph_creators/computations/shaper_computation.py
@@ -189,7 +189,7 @@ class ShaperComputation:
     def _calibrate_shaper(self, datas: np.ndarray, max_smoothing: Optional[float], scv: float, max_freq: float):
         """Find the best shaper parameters using Klipper's official algorithm"""
         shaper_calibrate, shaper_defs = get_shaper_calibrate_module()
-        calib_data = shaper_calibrate.process_accelerometer_data(datas)
+        calib_data = shaper_calibrate.process_accelerometer_data(None, datas)
         calib_data.normalize_to_frequencies()
 
         # We compute the damping ratio using the Klipper's default value if it fails

--- a/shaketune/graph_creators/computations/vibrations_computation.py
+++ b/shaketune/graph_creators/computations/vibrations_computation.py
@@ -70,7 +70,7 @@ class VibrationsComputation:
                 continue  # Measurement data is not in the expected format or is empty, skip it
 
             angle, speed = self._extract_angle_and_speed(measurement['name'])
-            freq_response = shaper_calibrate.process_accelerometer_data(data)
+            freq_response = shaper_calibrate.process_accelerometer_data(None, data)
             first_freqs = freq_response.freq_bins
             psd_sum = freq_response.psd_sum
 


### PR DESCRIPTION
Commit 2aff840 in klipper added a name parameter to CalibrationData and that gets passed through by process_accelerometer_data. I think this is only used for file naming by klipper, and shaketune handles its own filenames, so it doesn't seem required. Klipper sets this as None at least once in its usage, so None seems appropriate.

## Summary by Sourcery

Bug Fixes:
- Restore compatibility with updated Klipper shaper_calibrate.process_accelerometer_data signature by providing a placeholder name argument.