### PR TITLE
Fix klipper dec2025 breaking change

### DIFF
--- a/shaketune/graph_creators/computations/belts_computation.py
+++ b/shaketune/graph_creators/computations/belts_computation.py
@@ -13,7 +13,7 @@ import numpy as np
 from ...helpers.accelerometer import Measurement
 from ...helpers.common_func import detect_peaks
 from ...helpers.console_output import ConsoleOutput
-from .. import get_shaper_calibrate_module
+from .. import get_shaper_calibrate_module, process_accelerometer_data_compat
 from ..base_models import GraphMetadata
 from ..computation_results import BeltsResult, SignalData
 
@@ -131,7 +131,7 @@ class BeltsComputation:
     def _compute_signal_data(self, data: np.ndarray, common_freqs: np.ndarray, max_freq: float) -> SignalData:
         """Compute signal data from raw measurements"""
         shaper_calibrate, _ = get_shaper_calibrate_module()
-        calibration_data = shaper_calibrate.process_accelerometer_data(data)
+        calibration_data = process_accelerometer_data_compat(shaper_calibrate, data)
 
         freqs = calibration_data.freq_bins[calibration_data.freq_bins <= max_freq]
         psd = calibration_data.get_psd('all')[calibration_data.freq_bins <= max_freq]

--- a/shaketune/graph_creators/computations/shaper_computation.py
+++ b/shaketune/graph_creators/computations/shaper_computation.py
@@ -14,7 +14,7 @@ from ...helpers.accelerometer import Measurement
 from ...helpers.common_func import compute_mechanical_parameters, detect_peaks
 from ...helpers.console_output import ConsoleOutput
 from ...helpers.spectrogram import compute_spectrogram
-from .. import get_shaper_calibrate_module
+from .. import find_best_shaper_compat, get_shaper_calibrate_module, process_accelerometer_data_compat
 from ..base_models import GraphMetadata
 from ..computation_results import ShaperResult
 
@@ -190,7 +190,7 @@ class ShaperComputation:
     def _calibrate_shaper(self, datas: np.ndarray, max_smoothing: Optional[float], scv: float, max_freq: float):
         """Find the best shaper parameters using Klipper's official algorithm"""
         shaper_calibrate, shaper_defs = get_shaper_calibrate_module()
-        calib_data = shaper_calibrate.process_accelerometer_data(datas)
+        calib_data = process_accelerometer_data_compat(shaper_calibrate, datas)
         calib_data.normalize_to_frequencies()
 
         # We compute the damping ratio using the Klipper's default value if it fails
@@ -201,7 +201,8 @@ class ShaperComputation:
         # best shaper choice and the full list of shapers that are set to the current machine response
         compat = False
         try:
-            k_shaper_choice, k_shapers = shaper_calibrate.find_best_shaper(
+            k_shaper_choice, k_shapers = find_best_shaper_compat(
+                shaper_calibrate,
                 calib_data,
                 shapers=None,
                 damping_ratio=zeta,
@@ -227,14 +228,15 @@ class ShaperComputation:
                 )
             )
             compat = True
-            k_shaper_choice, k_shapers = shaper_calibrate.find_best_shaper(calib_data, max_smoothing, None)
+            k_shaper_choice, k_shapers = find_best_shaper_compat(shaper_calibrate, calib_data, max_smoothing, None)
 
         # Then in a second time, we run again the same computation but with a super low smoothing value to
         # get the maximum accelerations values for each algorithms.
         if compat:
-            _, k_shapers_max = shaper_calibrate.find_best_shaper(calib_data, MIN_SMOOTHING, None)
+            _, k_shapers_max = find_best_shaper_compat(shaper_calibrate, calib_data, MIN_SMOOTHING, None)
         else:
-            _, k_shapers_max = shaper_calibrate.find_best_shaper(
+            _, k_shapers_max = find_best_shaper_compat(
+                shaper_calibrate,
                 calib_data,
                 shapers=None,
                 damping_ratio=zeta,

--- a/shaketune/graph_creators/computations/shaper_computation.py
+++ b/shaketune/graph_creators/computations/shaper_computation.py
@@ -104,14 +104,21 @@ class ShaperComputation:
         perf_shaper_accel = 0
         max_smoothing_computed = 0
         for shaper in k_shapers:
+            # Resample vals to match calibration_data.freqs if needed (new Klipper API from dec 2025)
+            if hasattr(shaper, 'freq_bins') and shaper.freq_bins is not None:
+                # New Klipper from dec 2025: shaper has its own freq_bins, resample to match filtered freqs
+                vals_resampled = np.interp(calibration_data.freqs, shaper.freq_bins, shaper.vals)
+            else:
+                # Older Klipper: vals matches calibration_data.freq_bins, just filter it
+                vals_resampled = shaper.vals[freqs <= self.max_freq]
+
             shaper_info = {
                 'type': shaper.name.upper(),
                 'frequency': shaper.freq,
                 'vibrations': shaper.vibrs,
                 'smoothing': shaper.smoothing,
                 'max_accel': shaper.max_accel,
-                'vals': shaper.vals,
-                'freq_bins': shaper.freq_bins if hasattr(shaper, 'freq_bins') else None,
+                'vals': vals_resampled,
             }
             shaper_table_data['shapers'].append(shaper_info)
             max_smoothing_computed = max(max_smoothing_computed, shaper.smoothing)

--- a/shaketune/graph_creators/computations/shaper_computation.py
+++ b/shaketune/graph_creators/computations/shaper_computation.py
@@ -104,9 +104,8 @@ class ShaperComputation:
         perf_shaper_accel = 0
         max_smoothing_computed = 0
         for shaper in k_shapers:
-            # Resample vals to match calibration_data.freqs if needed (new Klipper API from dec 2025)
             if hasattr(shaper, 'freq_bins') and shaper.freq_bins is not None:
-                # New Klipper from dec 2025: shaper has its own freq_bins, resample to match filtered freqs
+                # New Klipper (Dec 2025+): shaper has its own freq_bins, resample to filtered freqs
                 vals_resampled = np.interp(calibration_data.freqs, shaper.freq_bins, shaper.vals)
             else:
                 # Older Klipper: vals matches calibration_data.freq_bins, just filter it

--- a/shaketune/graph_creators/computations/shaper_computation.py
+++ b/shaketune/graph_creators/computations/shaper_computation.py
@@ -111,6 +111,7 @@ class ShaperComputation:
                 'smoothing': shaper.smoothing,
                 'max_accel': shaper.max_accel,
                 'vals': shaper.vals,
+                'freq_bins': shaper.freq_bins if hasattr(shaper, 'freq_bins') else None,
             }
             shaper_table_data['shapers'].append(shaper_info)
             max_smoothing_computed = max(max_smoothing_computed, shaper.smoothing)

--- a/shaketune/graph_creators/computations/vibrations_computation.py
+++ b/shaketune/graph_creators/computations/vibrations_computation.py
@@ -17,7 +17,7 @@ from ...helpers.accelerometer import Measurement
 from ...helpers.common_func import compute_mechanical_parameters, detect_peaks, identify_low_energy_zones
 from ...helpers.console_output import ConsoleOutput
 from ...helpers.motors_config_parser import Motor
-from .. import get_shaper_calibrate_module
+from .. import get_shaper_calibrate_module, process_accelerometer_data_compat
 from ..base_models import GraphMetadata
 from ..computation_results import VibrationsResult
 
@@ -70,7 +70,7 @@ class VibrationsComputation:
                 continue  # Measurement data is not in the expected format or is empty, skip it
 
             angle, speed = self._extract_angle_and_speed(measurement['name'])
-            freq_response = shaper_calibrate.process_accelerometer_data(data)
+            freq_response = process_accelerometer_data_compat(shaper_calibrate, data)
             first_freqs = freq_response.freq_bins
             psd_sum = freq_response.psd_sum
 

--- a/shaketune/graph_creators/plotters/shaper_plotter.py
+++ b/shaketune/graph_creators/plotters/shaper_plotter.py
@@ -11,7 +11,6 @@ from typing import Any, Dict
 
 import matplotlib
 import matplotlib.pyplot as plt
-import numpy as np
 from matplotlib.figure import Figure
 
 from ..base_models import PlotterStrategy
@@ -129,23 +128,16 @@ class ShaperPlotter(PlotterStrategy):
         # Plot shaper filters on secondary axis
         ax_2 = ax.twinx()
         ax_2.yaxis.set_visible(False)
-        for shaper in data['shapers']:
-            # New Klipper has freq_bins in CalibrationResult, use it if available
-            shaper_freqs = shaper.freq_bins if hasattr(shaper, 'freq_bins') and shaper.freq_bins is not None else freqs
-            ax_2.plot(shaper_freqs, shaper.vals, label=shaper.name.upper(), linestyle='dotted')
+        for shaper in data['shaper_table_data']['shapers']:
+            ax_2.plot(freqs, shaper['vals'], label=shaper['type'], linestyle='dotted')
 
         # Draw shaper filtered PSDs
         shaper_choices = data['shaper_choices']
         for shaper in data['shaper_table_data']['shapers']:
-            # Interpolate vals to match calibration_data.freqs if freq_bins is different (new Klipper API)
-            if shaper['freq_bins'] is not None:
-                interp_vals = np.interp(freqs, shaper['freq_bins'], shaper['vals'])
-            else:
-                interp_vals = shaper['vals']
             if shaper['type'] == shaper_choices[0]:
-                ax.plot(freqs, psd * interp_vals, label=f'With {shaper_choices[0]} applied', color='cyan')
+                ax.plot(freqs, psd * shaper['vals'], label=f'With {shaper_choices[0]} applied', color='cyan')
             if len(shaper_choices) > 1 and shaper['type'] == shaper_choices[1]:
-                ax.plot(freqs, psd * interp_vals, label=f'With {shaper_choices[1]} applied', color='lime')
+                ax.plot(freqs, psd * shaper['vals'], label=f'With {shaper_choices[1]} applied', color='lime')
 
         # Draw detected peaks
         peaks = data['peaks']


### PR DESCRIPTION
## Summary by Sourcery

Add compatibility layer for recent Klipper shaper calibration API changes and adjust computations/plots to work across old and new versions.

Bug Fixes:
- Handle process_accelerometer_data signature changes via a compatibility wrapper so accelerometer processing works with new and old Klipper releases.
- Normalize find_best_shaper return values across Klipper versions to consistently obtain both the chosen shaper and its result set.
- Resample shaper response values to the calibration frequency grid for newer Klipper versions that expose per-shaper freq_bins, ensuring correct shaper tables and plots.
- Update shaper frequency profile plotting to use the precomputed shaper table data structure.
- Use the new compatibility wrappers in belts and vibrations computations so all analyses remain functional with the updated Klipper API.

Enhancements:
- Expose helper functions for obtaining the shaper_calibrate module and calling the Klipper shaper APIs in a version-agnostic way from graph creators.