### PR TITLE
v6.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,11 @@ target/
 profile_default/
 ipython_config.py
 
+.claude/
+CLAUDE.md
+
+.ruff_cache/
+
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:

--- a/docs/macros/axes_shaper_calibrations.md
+++ b/docs/macros/axes_shaper_calibrations.md
@@ -71,6 +71,8 @@ Regarding printer components, I do not recommend using an extra-light X-beam (al
 
 Finally, keep in mind that each axis has its own properties, such as mass and geometry, which will lead to different behaviors for each of them and will require different filters. Using the same input shaping settings for both axes is only valid if both axes are similar mechanically: this may be true for some machines, mainly Cross gantry configurations such as [CroXY](https://github.com/CroXY3D/CroXY) or [Annex-Engineering](https://github.com/Annex-Engineering) printers, but not for others.
 
+If the recommended accelerations in the table all show as **zero**, your Square Corner Velocity (SCV) is likely set too high. The max_accel value is computed by finding the highest acceleration that still keeps smoothing at an acceptable level given your SCV. When SCV is excessively high, even a very low acceleration produces too much smoothing, so the algorithm returns zero. You shouldn't use an SCV that high anyway, as it serves no real purpose and will cause defects in corners and infill anchors (similar to having too high a pressure advance). A good rule of thumb is to take your maximum print acceleration and divide it by 1000, with a maximum value of around 12-15. For example, if you print at 5000 mm/s², an SCV of 5 is a good starting point.
+
 
 ## Examples of graphs
 

--- a/docs/macros/create_vibrations_profile.md
+++ b/docs/macros/create_vibrations_profile.md
@@ -15,6 +15,7 @@ Call the `CREATE_VIBRATIONS_PROFILE` macro with the speed range you want to meas
 |-----------:|---------------|-------------|
 |SIZE|100|diameter in mm of the circle in which the recorded movements take place|
 |Z_HEIGHT|20|Z height to put the toolhead before starting the movements. Be careful, if your accelerometer is mounted under the nozzle, increase it to avoid crashing it on the bed of the machine|
+|MIN_SPEED|2|minimum speed of the toolhead in mm/s for the start of the analysis. Increase this on underpowered systems if you experience accelerometer data timeouts at very low speeds|
 |MAX_SPEED|200|maximum speed of the toolhead in mm/s to record for analysis|
 |SPEED_INCREMENT|2|toolhead speed increments in mm/s between each movement|
 |ACCEL|3000|accel in mm/s^2 used for all moves. Try to keep it relatively low to avoid dynamic effects that alter the measurements, but high enough to achieve a constant speed for >~70% of the segments. 3000 is a reasonable default for most printers, unless you want to record at very high speed, in which case you will want to increase SIZE and decrease ACCEL a bit.|

--- a/docs/macros/excitate_axis_at_freq.md
+++ b/docs/macros/excitate_axis_at_freq.md
@@ -15,6 +15,8 @@ Here are the parameters available:
 |ACCEL_PER_HZ|None (default to `[resonance_tester]` value)|accel per Hz value used for the test|
 |AXIS|x|axis you want to excitate. Can be set to either "x", "y", "a", "b"|
 |TRAVEL_SPEED|120|speed in mm/s used for all the travel movements (to go to the start position prior to the test)|
+|X_POS|None|X position wanted for the test. This value can be used if needed to override the X value of the probe_point set in your `[resonance_tester]` config section|
+|Y_POS|None|Y position wanted for the test. This value can be used if needed to override the Y value of the probe_point set in your `[resonance_tester]` config section|
 |Z_HEIGHT|None|Z height wanted for the test. This value can be used if needed to override the Z value of the probe_point set in your `[resonance_tester]` config section|
 |ACCEL_CHIP|None|accelerometer chip name from your Klipper config that you want to force for the test|
 
@@ -34,5 +36,5 @@ The energy accumulation plot shows the cumulative energy over time, integrated o
   - From the 4th to the 8th second of the test, I touched the toolhead, which has the most vibration reduction because it's the main component vibrating at that frequency and touching it dampens it a lot.
   - From the 14th to the 18th second, I touched the belts and this reduced the vibration a bit, but not as much as touching the toolhead.
   - From the 23rd to the 27th second, I touched the left XY joint of my machine and it didn't have any noticeable effect on the vibrations.
-  
+
 But as mentioned above, **remember that this doesn't mean that the left XY joint doesn't contribute to the vibrations**. It means that its vibrations aren't causing a problem in the recorded toolhead vibrations (because the accelerometer was mounted on the toolhead!!!), but if you find that this actually also reduces the global noise to your ears, you may want to start a new recording by sticking the accelerometer directly on the XY joint (or the problematic component) instead to continue diagnosing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["hatchling>=1.27.0", "hatch-vcs>=0.4.0"]
+build-backend = "hatchling.build"
+
 [project]
 name = "shake_n_tune"
 description = "Klipper streamlined input shaper workflow and calibration tools"
@@ -8,6 +12,13 @@ authors = [
 ]
 keywords = ["klipper", "input shaper", "calibration", "3d printer"]
 license = {file = "LICENSE"}
+dependencies = [
+  "GitPython==3.1.41",
+  "matplotlib==3.9.4",
+  "numpy==2.0.2 ; python_full_version < '3.10'",
+  "numpy==2.2.2 ; python_full_version >= '3.10'",
+  "zstandard==0.23.0",
+]
 dynamic = ["version"]
 
 [project.urls]
@@ -15,6 +26,20 @@ Repository = "https://github.com/Frix-x/klippain-shaketune"
 Documentation = "https://github.com/Frix-x/klippain-shaketune/tree/main/docs"
 Issues = "https://github.com/Frix-x/klippain-shaketune/issues"
 Changelog = "https://github.com/Frix-x/klippain-shaketune/releases"
+
+[dependency-groups]
+dev = [
+  "ruff>=0.11.0",
+]
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.targets.wheel]
+packages = ["shaketune"]
+
+[tool.uv]
+default-groups = ["dev"]
 
 [tool.ruff]
 line-length = 120 # We all have modern screens now and I believe this should be brought in line with current technology

--- a/shaketune/commands/create_vibrations_profile.py
+++ b/shaketune/commands/create_vibrations_profile.py
@@ -17,14 +17,13 @@ from ..helpers.console_output import ConsoleOutput
 from ..helpers.motors_config_parser import MotorsConfigParser
 from ..shaketune_process import ShakeTuneProcess
 
-MIN_SPEED = 2  # mm/s
-
 
 def create_vibrations_profile(gcmd, config, st_process: ShakeTuneProcess) -> None:
     date = datetime.now().strftime('%Y%m%d_%H%M%S')
 
     size = gcmd.get_float('SIZE', default=100.0, minval=50.0)
     z_height = gcmd.get_float('Z_HEIGHT', default=20.0)
+    min_speed = gcmd.get_float('MIN_SPEED', default=2.0, minval=1.0)
     max_speed = gcmd.get_float('MAX_SPEED', default=200.0, minval=10.0)
     speed_increment = gcmd.get_float('SPEED_INCREMENT', default=2.0, minval=1.0)
     accel = gcmd.get_int('ACCEL', default=3000, minval=100)
@@ -33,6 +32,9 @@ def create_vibrations_profile(gcmd, config, st_process: ShakeTuneProcess) -> Non
 
     if accel_chip == '':
         accel_chip = None
+
+    if min_speed >= max_speed:
+        raise gcmd.error('MIN_SPEED must be lower than MAX_SPEED!')
 
     if (size / (max_speed / 60)) < 0.25:
         raise gcmd.error(
@@ -88,7 +90,7 @@ def create_vibrations_profile(gcmd, config, st_process: ShakeTuneProcess) -> Non
     filename = creator.get_folder() / f'{creator.get_type().replace(" ", "")}_{date}'
     measurements_manager = MeasurementsManager(st_process.get_st_config().chunk_size, printer.get_reactor(), filename)
 
-    nb_speed_samples = int((max_speed - MIN_SPEED) / speed_increment + 1)
+    nb_speed_samples = int((max_speed - min_speed) / speed_increment + 1)
     for curr_angle in main_angles:
         ConsoleOutput.print(f'-> Measuring angle: {curr_angle} degrees...')
         radian_angle = math.radians(curr_angle)
@@ -108,7 +110,7 @@ def create_vibrations_profile(gcmd, config, st_process: ShakeTuneProcess) -> Non
 
         # Sweep the speed range to record the vibrations at different speeds
         for curr_speed_sample in range(nb_speed_samples):
-            curr_speed = MIN_SPEED + curr_speed_sample * speed_increment
+            curr_speed = min_speed + curr_speed_sample * speed_increment
             ConsoleOutput.print(f'Current speed: {curr_speed} mm/s')
 
             # Reduce the segments length for the lower speed range (0-100mm/s). The minimum length is 1/3 of the SIZE and is gradually increased

--- a/shaketune/commands/excitate_axis_at_freq.py
+++ b/shaketune/commands/excitate_axis_at_freq.py
@@ -26,6 +26,8 @@ def excitate_axis_at_freq(gcmd, klipper_config, st_process: ShakeTuneProcess) ->
     accel_per_hz = gcmd.get_float('ACCEL_PER_HZ', default=None)
     axis = gcmd.get('AXIS', default='x').lower()
     feedrate_travel = gcmd.get_float('TRAVEL_SPEED', default=120.0, minval=20.0)
+    x_pos = gcmd.get_float('X_POS', default=None)
+    y_pos = gcmd.get_float('Y_POS', default=None)
     z_height = gcmd.get_float('Z_HEIGHT', default=None, minval=1)
     accel_chip = gcmd.get('ACCEL_CHIP', default=None)
 
@@ -79,14 +81,19 @@ def excitate_axis_at_freq(gcmd, klipper_config, st_process: ShakeTuneProcess) ->
         # Use center of bed in case the test point in [resonance_tester] is set to -1,-1,-1
         # This is usefull to get something automatic and is also used in the Klippain modular config
         kin_info = toolhead.kin.get_status(systime)
-        mid_x = (kin_info['axis_minimum'].x + kin_info['axis_maximum'].x) / 2
-        mid_y = (kin_info['axis_minimum'].y + kin_info['axis_maximum'].y) / 2
-        point = (mid_x, mid_y, z_height)
+        x = (kin_info['axis_minimum'].x + kin_info['axis_maximum'].x) / 2
+        y = (kin_info['axis_minimum'].y + kin_info['axis_maximum'].y) / 2
+        z = z_height
     else:
         x, y, z = test_points[0]
         if z_height is not None:
             z = z_height
-        point = (x, y, z)
+
+    if x_pos is not None:
+        x = x_pos
+    if y_pos is not None:
+        y = y_pos
+    point = (x, y, z)
 
     toolhead.manual_move(point, feedrate_travel)
     toolhead.dwell(0.5)

--- a/shaketune/dummy_macros.cfg
+++ b/shaketune/dummy_macros.cfg
@@ -11,29 +11,17 @@
 [gcode_macro EXCITATE_AXIS_AT_FREQ]
 description: dummy
 gcode:
-    {% set create_graph = params.CREATE_GRAPH|default(0) %}
-    {% set frequency = params.FREQUENCY|default(25) %}
-    {% set duration = params.DURATION|default(30) %}
-    {% set accel_per_hz = params.ACCEL_PER_HZ %}
-    {% set axis = params.AXIS|default('x') %}
-    {% set travel_speed = params.TRAVEL_SPEED|default(120) %}
-    {% set x_pos = params.X_POS %}
-    {% set y_pos = params.Y_POS %}
-    {% set z_height = params.Z_HEIGHT %}
-    {% set accel_chip = params.ACCEL_CHIP %}
-    {% set params_filtered = {
-        "CREATE_GRAPH": create_graph,
-        "FREQUENCY": frequency,
-        "DURATION": duration,
-        "ACCEL_PER_HZ": accel_per_hz if accel_per_hz is not none else '',
-        "AXIS": axis,
-        "TRAVEL_SPEED": travel_speed,
-        "X_POS": x_pos if x_pos is not none else '',
-        "Y_POS": y_pos if y_pos is not none else '',
-        "Z_HEIGHT": z_height if z_height is not none else '',
-        "ACCEL_CHIP": accel_chip if accel_chip is not none else ''
-    } %}
-    _EXCITATE_AXIS_AT_FREQ {% for key, value in params_filtered.items() if value is defined and value is not none and value != '' %}{key}={value} {% endfor %}
+    {% set dummy = params.CREATE_GRAPH|default(0) %}
+    {% set dummy = params.FREQUENCY|default(25) %}
+    {% set dummy = params.DURATION|default(30) %}
+    {% set dummy = params.ACCEL_PER_HZ %}
+    {% set dummy = params.AXIS|default('x') %}
+    {% set dummy = params.TRAVEL_SPEED|default(120) %}
+    {% set dummy = params.X_POS %}
+    {% set dummy = params.Y_POS %}
+    {% set dummy = params.Z_HEIGHT %}
+    {% set dummy = params.ACCEL_CHIP %}
+    _EXCITATE_AXIS_AT_FREQ {% for key, value in params.items() if value is not none and value != '' %}{key}="{value}" {% endfor %}
 
 
 [gcode_macro AXES_MAP_CALIBRATION]
@@ -43,61 +31,38 @@ gcode:
     {% set dummy = params.SPEED|default(80) %}
     {% set dummy = params.ACCEL|default(1500) %}
     {% set dummy = params.TRAVEL_SPEED|default(120) %}
-    _AXES_MAP_CALIBRATION {rawparams}
+    _AXES_MAP_CALIBRATION {% for key, value in params.items() if value is not none and value != '' %}{key}="{value}" {% endfor %}
 
 
 [gcode_macro COMPARE_BELTS_RESPONSES]
 description: dummy
 gcode:
-    {% set freq_start = params.FREQ_START %}
-    {% set freq_end = params.FREQ_END %}
-    {% set hz_per_sec = params.HZ_PER_SEC|default(1) %}
-    {% set accel_per_hz = params.ACCEL_PER_HZ %}
-    {% set travel_speed = params.TRAVEL_SPEED|default(120) %}
-    {% set z_height = params.Z_HEIGHT %}
-    {% set max_scale = params.MAX_SCALE %}
-    {% set accel_chip = params.ACCEL_CHIP %}
-    {% set params_filtered = {
-        "FREQ_START": freq_start if freq_start is not none else '',
-        "FREQ_END": freq_end if freq_end is not none else '',
-        "HZ_PER_SEC": hz_per_sec,
-        "ACCEL_PER_HZ": accel_per_hz if accel_per_hz is not none else '',
-        "TRAVEL_SPEED": travel_speed,
-        "Z_HEIGHT": z_height if z_height is not none else '',
-        "MAX_SCALE": max_scale if max_scale is not none else '',
-        "ACCEL_CHIP": accel_chip if accel_chip is not none else ''
-    } %}
-    _COMPARE_BELTS_RESPONSES {% for key, value in params_filtered.items() if value is defined and value is not none and value != '' %}{key}={value} {% endfor %}
+    {% set dummy = params.FREQ_START %}
+    {% set dummy = params.FREQ_END %}
+    {% set dummy = params.HZ_PER_SEC|default(1) %}
+    {% set dummy = params.ACCEL_PER_HZ %}
+    {% set dummy = params.TRAVEL_SPEED|default(120) %}
+    {% set dummy = params.Z_HEIGHT %}
+    {% set dummy = params.MAX_SCALE %}
+    {% set dummy = params.ACCEL_CHIP %}
+    _COMPARE_BELTS_RESPONSES {% for key, value in params.items() if value is not none and value != '' %}{key}="{value}" {% endfor %}
 
 
 [gcode_macro AXES_SHAPER_CALIBRATION]
 description: dummy
 gcode:
-    {% set freq_start = params.FREQ_START %}
-    {% set freq_end = params.FREQ_END %}
-    {% set hz_per_sec = params.HZ_PER_SEC|default(1) %}
-    {% set accel_per_hz = params.ACCEL_PER_HZ %}
-    {% set axis = params.AXIS|default('all') %}
-    {% set scv = params.SCV %}
-    {% set max_smoothing = params.MAX_SMOOTHING %}
-    {% set travel_speed = params.TRAVEL_SPEED|default(120) %}
-    {% set z_height = params.Z_HEIGHT %}
-    {% set max_scale = params.MAX_SCALE %}
-    {% set accel_chip = params.ACCEL_CHIP %}
-    {% set params_filtered = {
-        "FREQ_START": freq_start if freq_start is not none else '',
-        "FREQ_END": freq_end if freq_end is not none else '',
-        "HZ_PER_SEC": hz_per_sec,
-        "ACCEL_PER_HZ": accel_per_hz if accel_per_hz is not none else '',
-        "AXIS": axis,
-        "SCV": scv if scv is not none else '',
-        "MAX_SMOOTHING": max_smoothing if max_smoothing is not none else '',
-        "TRAVEL_SPEED": travel_speed,
-        "Z_HEIGHT": z_height if z_height is not none else '',
-        "MAX_SCALE": max_scale if max_scale is not none else '',
-        "ACCEL_CHIP": accel_chip if accel_chip is not none else ''
-    } %}
-    _AXES_SHAPER_CALIBRATION {% for key, value in params_filtered.items() if value is defined and value is not none and value != '' %}{key}={value} {% endfor %}
+    {% set dummy = params.FREQ_START %}
+    {% set dummy = params.FREQ_END %}
+    {% set dummy = params.HZ_PER_SEC|default(1) %}
+    {% set dummy = params.ACCEL_PER_HZ %}
+    {% set dummy = params.AXIS|default('all') %}
+    {% set dummy = params.SCV %}
+    {% set dummy = params.MAX_SMOOTHING %}
+    {% set dummy = params.TRAVEL_SPEED|default(120) %}
+    {% set dummy = params.Z_HEIGHT %}
+    {% set dummy = params.MAX_SCALE %}
+    {% set dummy = params.ACCEL_CHIP %}
+    _AXES_SHAPER_CALIBRATION {% for key, value in params.items() if value is not none and value != '' %}{key}="{value}" {% endfor %}
 
 
 [gcode_macro CREATE_VIBRATIONS_PROFILE]
@@ -111,4 +76,4 @@ gcode:
     {% set dummy = params.ACCEL|default(3000) %}
     {% set dummy = params.TRAVEL_SPEED|default(120) %}
     {% set dummy = params.ACCEL_CHIP %}
-    _CREATE_VIBRATIONS_PROFILE {rawparams}
+    _CREATE_VIBRATIONS_PROFILE {% for key, value in params.items() if value is not none and value != '' %}{key}="{value}" {% endfor %}

--- a/shaketune/dummy_macros.cfg
+++ b/shaketune/dummy_macros.cfg
@@ -1,8 +1,8 @@
 # Shake&Tune: 3D printer analysis tools
-# 
+#
 # Copyright (C) 2024 Félix Boisselier <felix@fboisselier.fr> (Frix_x on Discord)
 # Licensed under the GNU General Public License v3.0 (GPL-3.0)
-# 
+#
 # File: dummy_macros.cfg
 # Description: Contains dummy gcode macros to inject at Klipper startup for
 #              availability in the UI, improving user experience with Shake&Tune.
@@ -17,6 +17,8 @@ gcode:
     {% set accel_per_hz = params.ACCEL_PER_HZ %}
     {% set axis = params.AXIS|default('x') %}
     {% set travel_speed = params.TRAVEL_SPEED|default(120) %}
+    {% set x_pos = params.X_POS %}
+    {% set y_pos = params.Y_POS %}
     {% set z_height = params.Z_HEIGHT %}
     {% set accel_chip = params.ACCEL_CHIP %}
     {% set params_filtered = {
@@ -26,6 +28,8 @@ gcode:
         "ACCEL_PER_HZ": accel_per_hz if accel_per_hz is not none else '',
         "AXIS": axis,
         "TRAVEL_SPEED": travel_speed,
+        "X_POS": x_pos if x_pos is not none else '',
+        "Y_POS": y_pos if y_pos is not none else '',
         "Z_HEIGHT": z_height if z_height is not none else '',
         "ACCEL_CHIP": accel_chip if accel_chip is not none else ''
     } %}

--- a/shaketune/dummy_macros.cfg
+++ b/shaketune/dummy_macros.cfg
@@ -105,6 +105,7 @@ description: dummy
 gcode:
     {% set dummy = params.SIZE|default(100) %}
     {% set dummy = params.Z_HEIGHT|default(20) %}
+    {% set dummy = params.MIN_SPEED|default(2) %}
     {% set dummy = params.MAX_SPEED|default(200) %}
     {% set dummy = params.SPEED_INCREMENT|default(2) %}
     {% set dummy = params.ACCEL|default(3000) %}


### PR DESCRIPTION
## Summary by Sourcery

Add configurability for vibration tests and document the new parameters.

New Features:
- Allow overriding the resonance test X and Y probe positions via X_POS and Y_POS parameters in excitate_axis_at_freq.
- Add a configurable MIN_SPEED parameter to CREATE_VIBRATIONS_PROFILE to control the starting speed of the sweep.

Bug Fixes:
- Prevent invalid vibration profiles by enforcing that MIN_SPEED is lower than MAX_SPEED.

Documentation:
- Document the new X_POS and Y_POS parameters for EXCITATE_AXIS_AT_FREQ and the MIN_SPEED parameter for CREATE_VIBRATIONS_PROFILE in the macros documentation.

Chores:
- Update dummy macros configuration to expose the new X_POS, Y_POS, and MIN_SPEED parameters.