### PR TITLE
build: add uv-compatible project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["hatchling>=1.27.0", "hatch-vcs>=0.4.0"]
+build-backend = "hatchling.build"
+
 [project]
 name = "shake_n_tune"
 description = "Klipper streamlined input shaper workflow and calibration tools"
@@ -8,6 +12,13 @@ authors = [
 ]
 keywords = ["klipper", "input shaper", "calibration", "3d printer"]
 license = {file = "LICENSE"}
+dependencies = [
+  "GitPython==3.1.41",
+  "matplotlib==3.9.4",
+  "numpy==2.0.2 ; python_full_version < '3.10'",
+  "numpy==2.2.2 ; python_full_version >= '3.10'",
+  "zstandard==0.23.0",
+]
 dynamic = ["version"]
 
 [project.urls]
@@ -15,6 +26,20 @@ Repository = "https://github.com/Frix-x/klippain-shaketune"
 Documentation = "https://github.com/Frix-x/klippain-shaketune/tree/main/docs"
 Issues = "https://github.com/Frix-x/klippain-shaketune/issues"
 Changelog = "https://github.com/Frix-x/klippain-shaketune/releases"
+
+[dependency-groups]
+dev = [
+  "ruff>=0.11.0",
+]
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.targets.wheel]
+packages = ["shaketune"]
+
+[tool.uv]
+default-groups = ["dev"]
 
 [tool.ruff]
 line-length = 120 # We all have modern screens now and I believe this should be brought in line with current technology


### PR DESCRIPTION
Add the project metadata needed to use uv as a development workflow
without changing the existing printer installation path.

What changed:
- expose runtime dependencies through pyproject.toml
- add a default dev dependency group for local tooling

Notes:
- this is intended for local development only
- the existing printer install flow based on requirements.txt is unchanged
