### PR TITLE
perf: speed up vibration analysis and reduce memory usage

### DIFF
--- a/shaketune/graph_creators/computations/axes_map_computation.py
+++ b/shaketune/graph_creators/computations/axes_map_computation.py
@@ -240,7 +240,7 @@ class AxesMapComputation:
         """Parse measurements into a dict keyed by axis name."""
         raw_datas = {}
         for measurement in self.measurements:
-            data = np.array(measurement['samples'])
+            data = np.asarray(measurement['samples'])
             if data is not None:
                 axis = measurement['name'].split('_')[1].lower()
                 raw_datas[axis] = data

--- a/shaketune/graph_creators/computations/belts_computation.py
+++ b/shaketune/graph_creators/computations/belts_computation.py
@@ -57,7 +57,7 @@ class BeltsComputation:
                 f'measurements named {[meas.get("name", "unknown") for meas in self.measurements]}'
             )
 
-        datas = [np.array(m['samples']) for m in self.measurements if m['samples'] is not None]
+        datas = [np.asarray(m['samples']) for m in self.measurements if m['samples'] is not None]
 
         # Get belt names for labels
         belt_info = {'A': ' (axis 1,-1)', 'B': ' (axis 1, 1)'}

--- a/shaketune/graph_creators/computations/shaper_computation.py
+++ b/shaketune/graph_creators/computations/shaper_computation.py
@@ -52,7 +52,7 @@ class ShaperComputation:
         if len(self.measurements) > 1:
             ConsoleOutput.print('Warning: incorrect number of measurements detected. Only the first one will be used!')
 
-        datas = [np.array(m['samples']) for m in self.measurements if m['samples'] is not None]
+        datas = [np.asarray(m['samples']) for m in self.measurements if m['samples'] is not None]
 
         # Compute shapers, PSD outputs and spectrogram
         (

--- a/shaketune/graph_creators/computations/static_frequency_computation.py
+++ b/shaketune/graph_creators/computations/static_frequency_computation.py
@@ -45,7 +45,7 @@ class StaticFrequencyComputation:
             ConsoleOutput.print('Warning: incorrect number of measurements detected. Only the first one will be used!')
 
         # Extract data from measurements
-        datas = [np.array(m['samples']) for m in self.measurements if m['samples'] is not None]
+        datas = [np.asarray(m['samples']) for m in self.measurements if m['samples'] is not None]
 
         # Compute spectrogram
         pdata, bins, t = compute_spectrogram(datas[0])

--- a/shaketune/graph_creators/computations/vibrations_computation.py
+++ b/shaketune/graph_creators/computations/vibrations_computation.py
@@ -272,39 +272,61 @@ class VibrationsComputation:
         # We want to project the motor vibrations measured on their own axes on the [0, 360] range
         spectrum_angles = np.linspace(0, 360, 720)  # One point every 0.5 degrees
         spectrum_speeds = np.linspace(min(measured_speeds), max(measured_speeds), len(measured_speeds) * 6)
-        spectrum_vibrations = np.zeros((len(spectrum_angles), len(spectrum_speeds)))
-
-        def get_interpolated_vibrations(data: dict, speed: float, speeds: List[float]) -> float:
-            idx = np.clip(np.searchsorted(speeds, speed, side='left'), 1, len(speeds) - 1)
-            lower_speed = speeds[idx - 1]
-            upper_speed = speeds[idx]
-            lower_vibrations = data.get(lower_speed, 0)
-            upper_vibrations = data.get(upper_speed, 0)
-            return lower_vibrations + (speed - lower_speed) * (upper_vibrations - lower_vibrations) / (
-                upper_speed - lower_speed
-            )
+        measured_speeds_arr = np.asarray(measured_speeds, dtype=float)
 
         # Precompute trigonometric values and constant before the loop
         angle_radians = np.deg2rad(spectrum_angles)
         cos_vals = np.cos(angle_radians)
         sin_vals = np.sin(angle_radians)
         sqrt_2_inv = 1 / math.sqrt(2)
+        speed_axis = spectrum_speeds[None, :]
 
-        # Compute the spectrum vibrations for each angle and speed combination
-        for target_angle_idx, (cos_val, sin_val) in enumerate(zip(cos_vals, sin_vals)):
-            for target_speed_idx, target_speed in enumerate(spectrum_speeds):
-                if kinematics in {'cartesian', 'limited_cartesian', 'corexz', 'limited_corexz'}:
-                    speed_1 = np.abs(target_speed * cos_val)
-                    speed_2 = np.abs(target_speed * sin_val)
-                elif kinematics in {'corexy', 'limited_corexy'}:
-                    speed_1 = np.abs(target_speed * (cos_val + sin_val) * sqrt_2_inv)
-                    speed_2 = np.abs(target_speed * (cos_val - sin_val) * sqrt_2_inv)
+        if kinematics in {'cartesian', 'limited_cartesian', 'corexz', 'limited_corexz'}:
+            speed_1 = np.abs(cos_vals[:, None] * speed_axis)
+            speed_2 = np.abs(sin_vals[:, None] * speed_axis)
+        elif kinematics in {'corexy', 'limited_corexy'}:
+            speed_1 = np.abs(((cos_vals + sin_vals) * sqrt_2_inv)[:, None] * speed_axis)
+            speed_2 = np.abs(((cos_vals - sin_vals) * sqrt_2_inv)[:, None] * speed_axis)
+        else:
+            raise ValueError(f'Unsupported kinematics for vibrations spectrogram: {kinematics}')
 
-                vibrations_1 = get_interpolated_vibrations(data[measured_angles[0]], speed_1, measured_speeds)
-                vibrations_2 = get_interpolated_vibrations(data[measured_angles[1]], speed_2, measured_speeds)
-                spectrum_vibrations[target_angle_idx, target_speed_idx] = vibrations_1 + vibrations_2
+        # Interpolate both measured motor curves in one batch per motor instead of per cell.
+        vibrations_1_curve = np.array([data[measured_angles[0]].get(speed, 0) for speed in measured_speeds_arr], dtype=float)
+        vibrations_2_curve = np.array([data[measured_angles[1]].get(speed, 0) for speed in measured_speeds_arr], dtype=float)
+
+        spectrum_vibrations = self._interp_with_linear_extrapolation(
+            speed_1.ravel(), measured_speeds_arr, vibrations_1_curve
+        ).reshape(speed_1.shape)
+        spectrum_vibrations += self._interp_with_linear_extrapolation(
+            speed_2.ravel(), measured_speeds_arr, vibrations_2_curve
+        ).reshape(speed_2.shape)
 
         return spectrum_angles, spectrum_speeds, spectrum_vibrations
+
+    def _interp_with_linear_extrapolation(
+        self, target_speeds: np.ndarray, measured_speeds: np.ndarray, vibration_curve: np.ndarray
+    ) -> np.ndarray:
+        """Vectorized interpolation that preserves the old linear extrapolation behavior at both ends."""
+        if measured_speeds.size == 1:
+            return np.full_like(target_speeds, vibration_curve[0], dtype=float)
+
+        interpolated = np.interp(target_speeds, measured_speeds, vibration_curve)
+
+        left_mask = target_speeds < measured_speeds[0]
+        if np.any(left_mask):
+            left_slope = (vibration_curve[1] - vibration_curve[0]) / (measured_speeds[1] - measured_speeds[0])
+            interpolated[left_mask] = vibration_curve[0] + (target_speeds[left_mask] - measured_speeds[0]) * left_slope
+
+        right_mask = target_speeds > measured_speeds[-1]
+        if np.any(right_mask):
+            right_slope = (vibration_curve[-1] - vibration_curve[-2]) / (
+                measured_speeds[-1] - measured_speeds[-2]
+            )
+            interpolated[right_mask] = (
+                vibration_curve[-1] + (target_speeds[right_mask] - measured_speeds[-1]) * right_slope
+            )
+
+        return interpolated
 
     def _compute_angle_powers(self, spectrogram_data: np.ndarray) -> np.ndarray:
         """Compute angle powers from spectrogram data"""

--- a/shaketune/graph_creators/computations/vibrations_computation.py
+++ b/shaketune/graph_creators/computations/vibrations_computation.py
@@ -65,7 +65,7 @@ class VibrationsComputation:
         shaper_calibrate, _ = get_shaper_calibrate_module()
 
         for measurement in self.measurements:
-            data = np.array(measurement['samples'])
+            data = np.asarray(measurement['samples'])
             if data is None:
                 continue  # Measurement data is not in the expected format or is empty, skip it
 

--- a/shaketune/helpers/accelerometer.py
+++ b/shaketune/helpers/accelerometer.py
@@ -18,7 +18,7 @@ import uuid
 from io import TextIOWrapper
 from multiprocessing import Process, Queue, Value
 from pathlib import Path
-from typing import List, Optional, Tuple, TypedDict
+from typing import List, Optional, Tuple, TypedDict, Union
 
 import numpy as np
 from zstandard import FLUSH_FRAME, ZstdCompressor, ZstdDecompressor
@@ -36,7 +36,7 @@ COMPRESSION_LEVEL = 11  # Zstandard compression level (0 to 22, higher is slower
 
 class Measurement(TypedDict):
     name: str
-    samples: SamplesList
+    samples: Union[SamplesList, np.ndarray]
 
 
 class MeasurementsManager:
@@ -75,13 +75,20 @@ class MeasurementsManager:
                             break
                         with is_writing.get_lock():
                             is_writing.value = True
-                        line = (json.dumps(meas) + '\n').encode('utf-8')
+                        line = (json.dumps(self._measurement_to_jsonable(meas)) + '\n').encode('utf-8')
                         compressor.write(line)
                         with is_writing.get_lock():
                             is_writing.value = False
                     compressor.flush(FLUSH_FRAME)
         except Exception as e:
             ConsoleOutput.print(f'Error writing to file {output_file}: {e}')
+
+    @staticmethod
+    def _measurement_to_jsonable(measurement: Measurement) -> dict:
+        samples = measurement.get('samples')
+        if isinstance(samples, np.ndarray):
+            samples = samples.tolist()
+        return {'name': measurement['name'], 'samples': samples}
 
     def clear_measurements(self, keep_last: bool = False):
         self.measurements = [self.measurements[-1]] if keep_last and self.measurements else []
@@ -195,6 +202,10 @@ class MeasurementsManager:
                     for line in text_stream:
                         if line.strip():
                             meas = json.loads(line)
+                            # Convert samples eagerly to NumPy arrays to avoid the high memory
+                            # overhead of nested Python lists and repeated array copies later on.
+                            if meas.get('samples') is not None:
+                                meas['samples'] = np.asarray(meas['samples'], dtype=np.float64)
                             measurements.append(meas)
             self.measurements = measurements
         except Exception as e:
@@ -240,8 +251,8 @@ class MeasurementsManager:
                         continue
 
                     # Add the parsed klipper raw accelerometer data to Shake&Tune measurements object
-                    samples = [tuple(row) for row in data]
                     if os.environ.get('SHAKETUNE_IN_CLI') != '1':
+                        samples = [tuple(row) for row in data]
                         # When running as a Klipper plugin, we can use the standard add_measurement method
                         self.add_measurement(name=logname.stem, samples=samples)
                     else:
@@ -249,7 +260,7 @@ class MeasurementsManager:
                         # as the add_measurement method requires a temp file to be set up for writing and that
                         # is not available when running like this or would need workarounds to be implemented.
                         # But it's not a big deal as the CLI mode is only used for single shot runs.
-                        self.measurements.append({'name': logname.stem, 'samples': samples})
+                        self.measurements.append({'name': logname.stem, 'samples': data})
             except Exception as err:
                 ConsoleOutput.print(f'Error while reading {logname}: {err}. It will be ignored by Shake&Tune!')
                 continue

--- a/tests/test_accelerometer_roundtrip.py
+++ b/tests/test_accelerometer_roundtrip.py
@@ -1,0 +1,79 @@
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+
+import shaketune.helpers.accelerometer as accelerometer_module
+from shaketune.helpers.accelerometer import MeasurementsManager
+
+
+class _FakeReactor:
+    def monotonic(self):
+        return time.monotonic()
+
+    def pause(self, waketime):
+        now = time.monotonic()
+        if waketime > now:
+            time.sleep(waketime - now)
+        return time.monotonic()
+
+
+class _ThreadProcess:
+    def __init__(self, target, args=(), daemon=False):
+        self._thread = threading.Thread(target=target, args=args, daemon=daemon)
+
+    def start(self):
+        self._thread.start()
+
+    def is_alive(self):
+        return self._thread.is_alive()
+
+
+class MeasurementsManagerRoundTripTest(unittest.TestCase):
+    def test_loaded_stdata_measurements_can_be_saved_again(self):
+        initial_samples = [
+            (0.0, 1.0, 2.0, 3.0),
+            (0.01, 1.5, 2.5, 3.5),
+            (0.02, 2.0, 3.0, 4.0),
+        ]
+        additional_samples = [
+            (0.0, 4.0, 5.0, 6.0),
+            (0.01, 4.5, 5.5, 6.5),
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            first_file = tmpdir_path / 'first.stdata'
+            second_file = tmpdir_path / 'second.stdata'
+
+            with patch.object(accelerometer_module, 'Process', _ThreadProcess):
+                writer = MeasurementsManager(chunk_size=1, k_reactor=_FakeReactor(), stdata_filename=first_file)
+                writer.add_measurement('first', initial_samples)
+                writer.save_stdata()
+
+                roundtrip = MeasurementsManager(chunk_size=1, k_reactor=_FakeReactor(), stdata_filename=second_file)
+                loaded_measurements = roundtrip.load_from_stdata(first_file)
+
+                self.assertEqual(len(loaded_measurements), 1)
+                self.assertIsInstance(loaded_measurements[0]['samples'], np.ndarray)
+                np.testing.assert_allclose(loaded_measurements[0]['samples'], np.asarray(initial_samples))
+
+                # Force the loaded NumPy-backed measurement back through the writer queue.
+                roundtrip.add_measurement('second', additional_samples)
+                roundtrip.save_stdata()
+
+                reloaded = MeasurementsManager(chunk_size=1).load_from_stdata(second_file)
+
+                self.assertEqual([measurement['name'] for measurement in reloaded], ['first', 'second'])
+                self.assertIsInstance(reloaded[0]['samples'], np.ndarray)
+                self.assertIsInstance(reloaded[1]['samples'], np.ndarray)
+                np.testing.assert_allclose(reloaded[0]['samples'], np.asarray(initial_samples))
+                np.testing.assert_allclose(reloaded[1]['samples'], np.asarray(additional_samples))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Performance Summary

Benchmarked on a Raspberry Pi over SSH using a temporary Python `3.13.5` venv and a fixed `vibrations` workload of `200` measurements / `500,000` samples. End-to-end timings below are best-of-2 runs using the real `vibrations` CLI.

## Executive Summary

The combination of the two diffs reduces end-to-end `vibrations` graph generation from `66.5s` at baseline (354ee4b) to `11.3s`, an `83.0%` reduction in runtime (`5.9x` faster). Peak RSS also drops from about `294 MB` to `196 MB`, a `33.6%` reduction.

Most of the speedup comes from the first commit, which vectorizes the directional spectrogram work and cuts runtime from `66.5s` to `11.9s` (`82.1%` faster). The second commit then improves the data-loading path by converting accelerometer samples to NumPy arrays earlier, trimming runtime further to `11.3s` and substantially reducing memory use, more than making up for the roughly 10MB additional memory usage from the vectorization.

## Per-commit Impact

- vectorized interpolation: `66.5s -> 11.9s` (`82.1%` faster)
- NumPy-at-load: `11.88s -> 11.32s` (`4.7%` faster), peak RSS reduced from about `294 MB` to `196 MB`

## Summary by Sourcery

Optimize vibration analysis computations and accelerometer data handling to improve performance and memory usage.

Enhancements:
- Vectorize directional spectrogram interpolation with a shared helper to reduce per-cell interpolation overhead while preserving edge extrapolation behavior.
- Allow measurements to carry NumPy arrays directly and convert samples to NumPy eagerly during stdata/CSV loading to lower memory usage and avoid redundant array copies.
- Standardize measurement consumers to use np.asarray for sample conversion across vibration, axes map, belts, shaper, and static frequency computations.

Tests:
- Add a round-trip test ensuring measurements loaded from stdata as NumPy arrays can be saved and reloaded without changing their content or type.