### PR TITLE
Fix shaper.vals/calibration_data.freqs length mismatch on some Kalico builds

### DIFF
--- a/shaketune/graph_creators/computations/shaper_computation.py
+++ b/shaketune/graph_creators/computations/shaper_computation.py
@@ -117,7 +117,15 @@ class ShaperComputation:
                 # (a mismatch here used to reach matplotlib as an opaque "x and y must have the same
                 # first dimension" crash -- see issue with max_freq=300 on KalicoCrew/kalico).
                 n = len(calibration_data.freqs)
-                if len(shaper.vals) < n:
+                if len(shaper.vals) == 0:
+                    # No edge element to replicate -- np.pad(mode='edge') would raise ValueError here
+                    ConsoleOutput.print(
+                        f'Warning: {shaper.name} returned no frequency bins at all; using zeros. This may '
+                        'indicate an unsupported Klipper/Kalico version -- the graph will show no data '
+                        'for this shaper.'
+                    )
+                    vals_resampled = np.zeros(n)
+                elif len(shaper.vals) < n:
                     ConsoleOutput.print(
                         f'Warning: {shaper.name} returned fewer frequency bins than expected '
                         f'({len(shaper.vals)} < {n}); padding with its last value. This may indicate '

--- a/shaketune/graph_creators/computations/shaper_computation.py
+++ b/shaketune/graph_creators/computations/shaper_computation.py
@@ -108,9 +108,25 @@ class ShaperComputation:
                 # New Klipper (Oct 2025+): shaper has its own freq_bins, resample to filtered freqs
                 vals_resampled = np.interp(calibration_data.freqs, shaper.freq_bins, shaper.vals)
             else:
-                # Older Klipper: vals is already filtered in fit_shaper to match freq_bins <= max_freq
-                # It should directly match calibration_data.freqs which was filtered the same way
-                vals_resampled = shaper.vals
+                # Older Klipper: fit_shaper filters vals against freq_bins <= max_freq internally,
+                # but its internal max_freq is `max(max_freq, test_freqs.max())` -- it can silently
+                # search past the max_freq we passed in (e.g. up to its own MAX_SHAPER_FREQ), which
+                # makes shaper.vals longer than calibration_data.freqs. Since freq_bins is sorted
+                # ascending, both arrays are prefixes of the same data, so truncating to the length
+                # we actually want recovers the correct values instead of assuming an exact match
+                # (a mismatch here used to reach matplotlib as an opaque "x and y must have the same
+                # first dimension" crash -- see issue with max_freq=300 on KalicoCrew/kalico).
+                n = len(calibration_data.freqs)
+                if len(shaper.vals) < n:
+                    ConsoleOutput.print(
+                        f'Warning: {shaper.name} returned fewer frequency bins than expected '
+                        f'({len(shaper.vals)} < {n}); padding with its last value. This may indicate '
+                        'an unsupported Klipper/Kalico version -- results near the high end of the '
+                        'graph may be inaccurate.'
+                    )
+                    vals_resampled = np.pad(shaper.vals, (0, n - len(shaper.vals)), mode='edge')
+                else:
+                    vals_resampled = shaper.vals[:n]
 
             shaper_info = {
                 'type': shaper.name.upper(),

--- a/shaketune/shaketune_process.py
+++ b/shaketune/shaketune_process.py
@@ -129,7 +129,7 @@ class ShakeTuneProcess:
             ConsoleOutput.print(f'Timeout error: {e}')
             return
         except Exception as e:
-            ConsoleOutput.print(f'Error while generating the graphs: {e}\n{traceback.print_exc()}')
+            ConsoleOutput.print(f'Error while generating the graphs: {e}\n{traceback.format_exc()}')
             return
 
         graph_creator.clean_old_files(self._config.keep_n_results)

--- a/test_shaper_length_mismatch.py
+++ b/test_shaper_length_mismatch.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Regression test for the shaper.vals <-> calibration_data.freqs length mismatch.
+
+Background: ShaperComputation.compute() (shaketune/graph_creators/computations/
+shaper_computation.py) used to assume that on older Klipper/Kalico builds (ones
+whose CalibrationResult has no `freq_bins` field), `shaper.vals` is already
+truncated to exactly match `calibration_data.freqs`. That assumption breaks
+whenever Kalico's own `fit_shaper` inflates its internal max_freq past what
+was passed in (`max_freq = max(max_freq, test_freqs.max())`), which happens
+whenever the requested max_freq is lower than the shaper search's own
+frequency ceiling (MAX_SHAPER_FREQ, 150Hz on KalicoCrew/kalico). The result
+was an unaligned array reaching matplotlib as an opaque "x and y must have
+same first dimension" crash during graph generation.
+
+This script drives the real ShaperComputation against a real Kalico/Klipper
+checkout with a synthetic capture, and asserts every shaper's `vals` is
+exactly aligned with `calibration_data.freqs` at a range of max_freq values
+-- including ones below and above MAX_SHAPER_FREQ, since the bug is only
+observable when the requested max_freq undercuts it.
+
+Usage:
+    python test_shaper_length_mismatch.py --klipper-dir /path/to/kalico/checkout
+"""
+
+import argparse
+import math
+import os
+import random
+import sys
+from importlib import import_module
+from pathlib import Path
+
+
+def build_synthetic_samples(sample_rate=3200.0, duration=2.0, seed=1234):
+    """A resonance-like raw accelerometer capture: dominant peak ~190Hz plus
+    broadband content out past 300Hz, so there's real data to truncate."""
+    random.seed(seed)
+    n = int(sample_rate * duration)
+    samples = []
+    for i in range(n):
+        t = i / sample_rate
+        decay = 1.0 if i < n * 0.9 else (n - i) / (n * 0.1)
+        x = (
+            3000.0 * decay * math.sin(2 * math.pi * 190.0 * t)
+            + 400.0 * math.sin(2 * math.pi * 45.0 * t)
+            + 150.0 * math.sin(2 * math.pi * 260.0 * t)
+            + random.uniform(-50, 50)
+        )
+        y = 200.0 * math.sin(2 * math.pi * 97.0 * t) + random.uniform(-30, 30)
+        z = random.uniform(-20, 20)
+        samples.append((t, x, y, z))
+    return samples
+
+
+def load_kalico_shaper_calibrate(klipper_dir):
+    """Mirrors shaketune.cli.load_klipper_module(): point sys.modules at the
+    real installed shaper_calibrate/shaper_defs so ShaperComputation runs
+    against actual firmware code, not a mock."""
+    os.environ['SHAKETUNE_IN_CLI'] = '1'
+    kdir = os.path.expanduser(klipper_dir)
+    sys.path.append(os.path.join(kdir, 'klippy'))
+    sys.modules['shaper_calibrate'] = import_module('.shaper_calibrate', 'extras')
+    sys.modules['shaper_defs'] = import_module('.shaper_defs', 'extras')
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        '--klipper-dir',
+        required=True,
+        help='Path to a Kalico/Klipper checkout (needs klippy/extras/shaper_calibrate.py)',
+    )
+    parser.add_argument(
+        '--max-freqs',
+        type=float,
+        nargs='+',
+        default=[80.0, 100.0, 149.0, 150.0, 151.0, 200.0, 250.0, 300.0],
+        help='max_freq values to test; below/around/above MAX_SHAPER_FREQ (150 on KalicoCrew/kalico) is the interesting range',
+    )
+    args = parser.parse_args()
+
+    load_kalico_shaper_calibrate(args.klipper_dir)
+
+    # Import after sys.path/sys.modules are set up, and after this script's own
+    # directory (the shaketune repo root) is importable.
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from shaketune.graph_creators.computations.shaper_computation import ShaperComputation
+
+    samples = build_synthetic_samples()
+    measurement = {'name': 'synthetic_x', 'samples': samples}
+
+    failures = []
+    for max_freq in args.max_freqs:
+        computation = ShaperComputation(
+            measurements=[measurement],
+            max_smoothing=None,
+            scv=5.0,
+            max_freq=max_freq,
+            test_params=None,
+            max_scale=None,
+            st_version='test',
+        )
+        result = computation.compute()
+        n_expected = len(result.calibration_data.freqs)
+        for shaper in result.shaper_table_data['shapers']:
+            n_actual = len(shaper['vals'])
+            status = 'OK' if n_actual == n_expected else 'MISMATCH'
+            print(
+                f'max_freq={max_freq:>6.1f}  {shaper["type"]:<12} vals={n_actual:<5} expected={n_expected:<5} {status}'
+            )
+            if n_actual != n_expected:
+                failures.append((max_freq, shaper['type'], n_actual, n_expected))
+
+    print()
+    if failures:
+        print(f'FAILED: {len(failures)} shaper/max_freq combination(s) had mismatched array lengths:')
+        for max_freq, name, actual, expected in failures:
+            print(f'  max_freq={max_freq}: {name} vals={actual} != freqs={expected}')
+        sys.exit(1)
+    else:
+        print(
+            f'PASSED: all shapers matched calibration_data.freqs length across {len(args.max_freqs)} max_freq value(s).'
+        )
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

`SHAPER_CALIBRATE` graph generation can crash with a `ValueError: x and y must have same first dimension, but have shapes (N,) and (M,)` matplotlib error, reported on `KalicoCrew/kalico:main` when a lower `max_freq` is configured (reproduced here with `max_freq < 150`).

**Root cause:** `ShaperComputation.compute()` assumes that on Klipper/Kalico builds where `CalibrationResult` has no `freq_bins` field, `shaper.vals` is already truncated to exactly match `calibration_data.freqs`. That assumption only holds when the requested `max_freq` is >= the shaper search's own internal frequency ceiling (`MAX_SHAPER_FREQ`, 150Hz on `KalicoCrew/kalico`). Internally, `fit_shaper` computes `max_freq = max(max_freq, test_freqs.max())` -- so a *lower* requested `max_freq` gets silently overridden, and `shaper.vals` ends up longer than `calibration_data.freqs`, which was truncated with the original (lower) value. That length mismatch reaches matplotlib as an opaque crash during graph generation.

## Fix

Since `freq_bins` is sorted ascending, both truncations are prefixes of the same underlying array -- slicing `shaper.vals` down to `len(calibration_data.freqs)` recovers the correct values without needing to know the installed Kalico/Klipper version's internal behavior. Falls back to edge-padding with a console warning in the (currently unobserved) case where `vals` is shorter than expected, rather than crashing.

Also fixes `traceback.print_exc()` being used inside an f-string in the graph-generation error handler (`shaketune_process.py`) -- it prints to stderr and returns `None`, which is why that error message always had a trailing literal `None` instead of the actual traceback.

## Testing

Added `test_shaper_length_mismatch.py`, which drives the real `ShaperComputation` against a real Kalico checkout (`KalicoCrew/kalico:main`) with a synthetic capture, across `max_freq` values from 80-300:

- **Before this fix:** fails for `max_freq` 80 and 100 (below `MAX_SHAPER_FREQ`) with the exact length-mismatch pattern; also reproduced the literal matplotlib crash end-to-end via `shaketune.cli`.
- **After this fix:** passes for all 8 tested `max_freq` values, no regressions at the values that already worked.

Also verified with `ruff check` / `ruff format --check` (both files clean).

## Summary by Sourcery

Handle length mismatches between shaper.vals and calibration_data.freqs on older Klipper/Kalico builds to prevent graph-generation crashes.

Bug Fixes:
- Prevent matplotlib graph generation from crashing when shaper.vals has a different length than calibration_data.freqs by truncating or padding shaper values as needed.
- Fix graph-generation error reporting so the full traceback is printed instead of a trailing literal 'None'.

Tests:
- Add a regression test script that runs ShaperComputation against a real Kalico/Klipper checkout across multiple max_freq values to verify shaper.vals aligns with calibration_data.freqs.